### PR TITLE
Increase selenium timeout

### DIFF
--- a/service_info/tests/test_frontend.py
+++ b/service_info/tests/test_frontend.py
@@ -82,8 +82,12 @@ class ServiceInfoFrontendTestCase(LiveServerTestCase):
             os.remove(full_path)
 
     def load_page_and_set_language(self, language='en', retries_left=2):
-        """Helper to set language choice in the browser."""
+        """Helper to set language choice in the browser.
 
+        Note: This intermittently times out on Travis, and lengthening the timeout does not help.
+        When reproduced locally (which is difficult), the screenshot of the site is empty. We
+        therefore reload the page completely if there is a timeout, up to a total of 3 times.
+        """
         self.browser.get(self.express_url)
         try:
             form = self.wait_for_element('language-toggle')
@@ -95,9 +99,8 @@ class ServiceInfoFrontendTestCase(LiveServerTestCase):
                 self.wait_for_element('li.menu-item-language a', match=By.CSS_SELECTOR).click()
             except TimeoutException:
                 if retries_left:
-                    self.load_page_and_set_language(language, retries_left - 1)
-                else:
-                    raise
+                    self.load_page_and_set_language(language, retries_left-1)
+                raise
             form = self.wait_for_element('language-toggle')
         button = form.find_element_by_css_selector('[data-lang="%s"]' % language)
         button.click()

--- a/service_info/tests/test_frontend.py
+++ b/service_info/tests/test_frontend.py
@@ -99,8 +99,9 @@ class ServiceInfoFrontendTestCase(LiveServerTestCase):
                 self.wait_for_element('li.menu-item-language a', match=By.CSS_SELECTOR).click()
             except TimeoutException:
                 if retries_left:
-                    self.load_page_and_set_language(language, retries_left-1)
-                raise
+                    self.load_page_and_set_language(language, retries_left - 1)
+                else:
+                    raise
             form = self.wait_for_element('language-toggle')
         button = form.find_element_by_css_selector('[data-lang="%s"]' % language)
         button.click()

--- a/service_info/tests/test_frontend.py
+++ b/service_info/tests/test_frontend.py
@@ -25,7 +25,7 @@ from services.models import Service
 from services.tests.factories import ProviderTypeFactory, ServiceFactory
 
 
-DEFAULT_TIMEOUT = 4  # Seconds
+DEFAULT_TIMEOUT = 40  # Seconds
 
 
 class ServiceInfoFrontendTestCase(LiveServerTestCase):


### PR DESCRIPTION
I reproduced failures locally by decreasing the timeout to 0.5 seconds, so figured it's worth a shot increasing the timeout for Travis.

I've run this build 3 times successfully: https://travis-ci.org/theirc/ServiceInfo/builds/70755833

40 seconds seems excessive, but I'm not sure how much futzing we want to do with it (assuming that this is the proper fix)