### PR TITLE
Add support for adding image to a service

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 psycopg2==2.5.4
-Pillow==2.5.3
+Pillow==2.9.0
 Django==1.7.7
 six==1.6.1
 celery==3.1.17
@@ -23,3 +23,6 @@ oauthlib==0.7.2
 xlwt-future==0.8.0
 # xlrd already supports Python 3, go figure
 xlrd==0.9.3
+
+# images / thumbnails
+sorl-thumbnail==12.3

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -164,6 +164,7 @@ INSTALLED_APPS = (
     'corsheaders',
     'rest_framework',
     'rest_framework.authtoken',
+    'sorl.thumbnail',
 )
 
 # A sample logging configuration. The only tangible logging

--- a/services/admin.py
+++ b/services/admin.py
@@ -6,6 +6,9 @@ from django.contrib.gis.forms import BaseGeometryWidget, PointField
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
+
+from sorl.thumbnail.admin import AdminImageMixin
+
 from services.models import Provider, Service, ServiceArea, SelectionCriterion, ProviderType, \
     ServiceType, JiraUpdateRecord, Feedback, Nationality, LebanonRegion, RequestForService
 from services.utils import validation_error_as_text
@@ -70,13 +73,9 @@ class ServiceAdminForm(forms.ModelForm):
         model = Service
 
 
-class ServiceAdmin(admin.ModelAdmin):
+class ServiceAdmin(AdminImageMixin, admin.ModelAdmin):
     form = ServiceAdminForm
 
-    class Media:
-        css = {
-            "all": ("css/admin_styles.css",)
-        }
     actions = ['approve', 'reject']
     fieldsets = (
         (None, {
@@ -115,6 +114,9 @@ class ServiceAdmin(admin.ModelAdmin):
         (_('Location'), {
             'fields': ['location'],
         }),
+        (_('Image'), {
+            'fields': ['image', ]
+        }),
     )
     inlines = [SelectionCriterionInlineAdmin]
     list_display = ['name_en', 'name_ar', 'name_fr',
@@ -122,6 +124,7 @@ class ServiceAdmin(admin.ModelAdmin):
                     'type',
                     'status',
                     'area_of_service',
+                    'show_image',
                     ]
     list_display_links = ['name_en', 'name_ar', 'name_fr', 'provider', 'area_of_service']
     list_filter = ['status', 'type']
@@ -204,6 +207,15 @@ class ServiceAdmin(admin.ModelAdmin):
                 msg = _('The service was rejected successfully.')
                 self.message_user(request, msg, messages.INFO)
         return super().response_change(request, obj)
+
+    def show_image(self, obj):
+        """Create a thumbnail of this image to show in the admin list."""
+        thumbnail_url = obj.get_thumbnail_url(height=100)
+        if thumbnail_url:
+            return '<img src="{}" />'.format(thumbnail_url)
+        return _("no image")
+    show_image.allow_tags = True
+    show_image.short_description = "Image"
 
 
 class ServiceAreaAdmin(admin.ModelAdmin):

--- a/services/migrations/0012_service_image.py
+++ b/services/migrations/0012_service_image.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sorl.thumbnail.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0011_auto_20150714_1809'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='service',
+            name='image',
+            field=sorl.thumbnail.fields.ImageField(upload_to='service-images/', help_text='Supported file types include GIF, JPEG, PNG, WebP. SVG files are not supported.', default='', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/services/models.py
+++ b/services/models.py
@@ -680,7 +680,7 @@ class Service(NameInCurrentLanguageMixin, models.Model):
     def get_thumbnail_url(self, width=100, height=100):
         """Shortcut to get the URL for an image thumbnail."""
         if self.image and hasattr(self.image, 'url'):
-            frmt = "PNG" if self.image.path.rsplit(".", 1)[-1].upper() == "PNG" else "JPEG"
+            frmt = "PNG" if self.image.path.lower().endswith('.png') else "JPEG"
             size = "{}x{}".format(width, height)
             thumbnail = get_thumbnail(self.image, size, upscale=False, format=frmt)
             return thumbnail.url

--- a/services/models.py
+++ b/services/models.py
@@ -10,6 +10,9 @@ from django.db.transaction import atomic
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _, get_language
 
+from sorl.thumbnail import ImageField
+from sorl.thumbnail.shortcuts import get_thumbnail
+
 from . import jira_support
 from .tasks import email_provider_about_service_approval_task
 from .utils import absolute_url
@@ -473,6 +476,14 @@ class Service(NameInCurrentLanguageMixin, models.Model):
 
     objects = models.GeoManager()
 
+    image = ImageField(
+        upload_to="service-images/",
+        help_text=_("Supported file types include GIF, JPEG, PNG, WebP. "
+                    "SVG files are not supported."),
+        blank=True,
+        default='',
+    )
+
     def get_api_url(self):
         return reverse('service-detail', args=[self.id])
 
@@ -665,6 +676,15 @@ class Service(NameInCurrentLanguageMixin, models.Model):
         if self.location is None:
             self.location = Point(0, 0)
         self.location[1] = value
+
+    def get_thumbnail_url(self, width=100, height=100):
+        """Shortcut to get the URL for an image thumbnail."""
+        if self.image and hasattr(self.image, 'url'):
+            frmt = "PNG" if self.image.path.rsplit(".", 1)[-1].upper() == "PNG" else "JPEG"
+            size = "{}x{}".format(width, height)
+            thumbnail = get_thumbnail(self.image, size, upscale=False, format=frmt)
+            return thumbnail.url
+        return None
 
 
 class JiraUpdateRecord(models.Model):

--- a/services/tests/factories.py
+++ b/services/tests/factories.py
@@ -106,6 +106,7 @@ class ServiceFactory(factory.DjangoModelFactory):
     type = factory.SubFactory(ServiceTypeFactory)
     location = FuzzyLocation()
     cost_of_service = factory.fuzzy.FuzzyText()
+    image = factory.django.ImageField()
 
 
 class SelectionCriterionFactory(factory.DjangoModelFactory):

--- a/services/tests/test_admin.py
+++ b/services/tests/test_admin.py
@@ -167,3 +167,14 @@ class ServiceAdminTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         self.assertIn('Only services in draft status may be rejected',
                       [str(msg) for msg in rsp.context['messages']])
+
+    def test_show_image_in_changelist(self):
+        rsp = self.client.get(reverse('admin:services_service_changelist'))
+        image_tag = '<img src="%s">' % self.service.get_thumbnail_url()
+        self.assertContains(rsp, image_tag, html=True)
+
+    def test_show_no_image_if_not_set(self):
+        self.service.image = ''
+        self.service.save()
+        rsp = self.client.get(reverse('admin:services_service_changelist'))
+        self.assertContains(rsp, 'no image')

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -430,6 +430,8 @@ class ServiceAPITest(APITestMixin, TestCase):
             {'text_en': 'Crit en'},
             {'text_fr': 'Crit fr'}
         ]
+        # image is read-only
+        del data['image']
         rsp = self.put_with_token(reverse('service-list'), data=data)
         self.assertEqual(METHOD_NOT_ALLOWED, rsp.status_code, msg=rsp.content.decode('utf-8'))
 


### PR DESCRIPTION
Addresses #14

This allows a staff user to add an image to a service via the admin, and
shows a thumbnail of that image in the changelist.

Nginx, by default, limits uploads to 1M, which may or may not be
sufficient. Maybe we should bump that to 5 or 10?