### PR TITLE
Add image to service detail page

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -237,6 +237,7 @@ class ServiceSerializer(RequireOneTranslationMixin,
                         serializers.HyperlinkedModelSerializer):
     provider_fetch_url = serializers.CharField(source='get_provider_fetch_url', read_only=True)
     selection_criteria = SelectionCriterionSerializerForService(many=True, required=False)
+    image_url = serializers.SerializerMethodField()
 
     class Meta:
         model = Service
@@ -260,7 +261,8 @@ class ServiceSerializer(RequireOneTranslationMixin,
             'friday_open', 'friday_close',
             'saturday_open', 'saturday_close',
             'type',
-            'is_mobile'
+            'is_mobile',
+            'image_url',
         )
         read_only_fields = ('provider',)
         required_translated_fields = ['name', 'description']
@@ -327,6 +329,9 @@ class ServiceSerializer(RequireOneTranslationMixin,
         user = self.context['request'].user
         kwargs['provider'] = Provider.objects.get(user=user)
         super().save(**kwargs)
+
+    def get_image_url(self, obj):
+        return obj.get_thumbnail_url(width=640, height=480)
 
 
 class DistanceField(serializers.FloatField):

--- a/frontend/templates/service-detail.hbs
+++ b/frontend/templates/service-detail.hbs
@@ -20,8 +20,11 @@
 		</div>
 	</div>
 </div>
-<div class="container">      
+<div class="container">
     <div class="row">
+        {{#if service.image_url }}
+            <div class="image"><img src="{{ service.image_url }}" alt="service photo" /></div>
+        {{/if}}
 		<div class="description">{{multiline service.description }}</div>
 		<div class=feedback-btn>
 			<div class="third">

--- a/services/models.py
+++ b/services/models.py
@@ -682,7 +682,7 @@ class Service(NameInCurrentLanguageMixin, models.Model):
         if self.image and hasattr(self.image, 'url'):
             frmt = "PNG" if self.image.path.lower().endswith('.png') else "JPEG"
             size = "{}x{}".format(width, height)
-            thumbnail = get_thumbnail(self.image, size, upscale=False, format=frmt)
+            thumbnail = get_thumbnail(self.image, size, upscale=False, format=frmt, crop='center')
             return thumbnail.url
         return None
 

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -525,6 +525,25 @@ class ServiceAPITest(APITestMixin, TestCase):
         service_type = json.loads(self.client.get(result['type']).content.decode('utf-8'))
         self.assertIn('icon_url', service_type)
 
+    def test_get_service_with_image(self):
+        # if Service has image, its URL should be available
+        service = ServiceFactory(provider=self.provider)
+        image_url = service.get_thumbnail_url(width=640, height=480)
+        rsp = self.get_with_token(service.get_api_url())
+        result = json.loads(rsp.content.decode('utf-8'))
+        self.assertEqual(service.pk, result['id'])
+        self.assertEqual(image_url, result['image_url'])
+
+    def test_get_service_with_no_image(self):
+        # if Service doesn't have image, its URL should be None
+        service = ServiceFactory(provider=self.provider)
+        service.image = ''
+        service.save()
+        rsp = self.get_with_token(service.get_api_url())
+        result = json.loads(rsp.content.decode('utf-8'))
+        self.assertEqual(service.pk, result['id'])
+        self.assertEqual(None, result['image_url'])
+
     def test_list_services(self):
         # Should only get user's own services
         provider = self.provider


### PR DESCRIPTION
* Adds `image_url` to Service API, which is a 640x480 thumbnail of the uploaded image
* Uses `crop=center` which avoids stretching portrait images, without negatively affecting landscape images
* If image is present, displays it on service detail page

Addresses #16