### PR TITLE
Responsive images

### DIFF
--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -128,7 +128,8 @@
       "Email": "Email Address",
       "Website": "Website",
       "Unknown": "Unknown",
-      "Criteria": "Selection Criteria"
+      "Criteria": "Selection Criteria",
+      "Picture": "Service Address Picture"
     }
   },
   "Service-Remove-Change": {

--- a/frontend/styles/site.less
+++ b/frontend/styles/site.less
@@ -2306,6 +2306,9 @@ Service-Detail
             }
 		}
 	}
+    .image img {
+        width: 100%;
+    }
 	.form-group span.control-label {
 		font-weight: 400;
 	}

--- a/frontend/templates/service-detail.hbs
+++ b/frontend/templates/service-detail.hbs
@@ -22,9 +22,6 @@
 </div>
 <div class="container">
     <div class="row">
-        {{#if service.image_url }}
-            <div class="image"><img src="{{ service.image_url }}" alt="service photo" /></div>
-        {{/if}}
 		<div class="description">{{multiline service.description }}</div>
 		<div class=feedback-btn>
 			<div class="third">
@@ -150,5 +147,22 @@
               </div>
           {{/each}}
         </div>
+        {{#if service.image_data }}
+          <div class="description">
+            <div class="row">
+              <span class="control-label" data-i18n="Service-Map.List.Picture"></span>
+            </div>
+            <div class="image">
+              <img src="{{ service.image_data.medium_url }}"
+                   alt="service photo"
+                   srcset="{{ service.image_data.large_url }} {{ service.image_data.large_width }}w,
+                           {{ service.image_data.medium_url }} {{ service.image_data.medium_width }}w,
+                           {{ service.image_data.small_url }} {{ service.image_data.small_width }}w"
+                   sizes="100vw"
+                   />
+            </div>
+          </div>
+        {{/if}}
+
     </div>
 </div>

--- a/services/migrations/0013_auto_20150727_2318.py
+++ b/services/migrations/0013_auto_20150727_2318.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sorl.thumbnail.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0012_service_image'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='service',
+            name='image',
+            field=sorl.thumbnail.fields.ImageField(blank=True, help_text='Upload an image file (GIF, JPEG, PNG, WebP) with a square aspect ratio (Width equal to Height). The image size should be at least 1280 x 1280 for best results. SVG files are not supported.', default='', upload_to='service-images/'),
+            preserve_default=True,
+        ),
+    ]

--- a/services/models.py
+++ b/services/models.py
@@ -478,8 +478,10 @@ class Service(NameInCurrentLanguageMixin, models.Model):
 
     image = ImageField(
         upload_to="service-images/",
-        help_text=_("Supported file types include GIF, JPEG, PNG, WebP. "
-                    "SVG files are not supported."),
+        help_text=_(
+            "Upload an image file (GIF, JPEG, PNG, WebP) with a square aspect "
+            "ratio (Width equal to Height). The image size should be at least "
+            "1280 x 1280 for best results. SVG files are not supported."),
         blank=True,
         default='',
     )

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -526,23 +526,25 @@ class ServiceAPITest(APITestMixin, TestCase):
         self.assertIn('icon_url', service_type)
 
     def test_get_service_with_image(self):
-        # if Service has image, its URL should be available
+        # if Service has image, its data should be available
         service = ServiceFactory(provider=self.provider)
-        image_url = service.get_thumbnail_url(width=640, height=480)
+        expected_fields = set(['large_url', 'large_width',
+                               'medium_url', 'medium_width',
+                               'small_url', 'small_width'])
         rsp = self.get_with_token(service.get_api_url())
         result = json.loads(rsp.content.decode('utf-8'))
         self.assertEqual(service.pk, result['id'])
-        self.assertEqual(image_url, result['image_url'])
+        self.assertEqual(expected_fields, set(result['image_data'].keys()))
 
     def test_get_service_with_no_image(self):
-        # if Service doesn't have image, its URL should be None
+        # if Service doesn't have image, its data should be None
         service = ServiceFactory(provider=self.provider)
         service.image = ''
         service.save()
         rsp = self.get_with_token(service.get_api_url())
         result = json.loads(rsp.content.decode('utf-8'))
         self.assertEqual(service.pk, result['id'])
-        self.assertEqual(None, result['image_url'])
+        self.assertEqual(None, result['image_data'])
 
     def test_list_services(self):
         # Should only get user's own services


### PR DESCRIPTION
Closes #43

This adds an api field to Service which has URLs and widths for large, medium,
and small images. The maximum pixel width that we'll use is about 640, but we
include a large (1280) image for high density screens.

The position of the image has been moved to the bottom of the detail screen.

The `srcset` attr specifies the image URLs and their width, and the
`sizes` attr specifies that we want to use 100% of the viewport. Those 
specifications are then used by the browser to pick an appropriate image. The
`src` param is included, which allows for non-supported browsers to fallback.