### PR TITLE
Only display English for the Django admin

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -79,7 +79,7 @@ class LanguageSerializer(serializers.Serializer):
 
     def validate_language(self, value):
         # See if it's a valid language code
-        language_dict = dict(settings.LANGUAGES)
+        language_dict = dict(settings.FRONTEND_LANGUAGES)
         if value not in language_dict:
             valid_codes = ', '.join(language_dict.keys())
             raise exceptions.ValidationError(
@@ -577,7 +577,7 @@ class BaseServiceTypeAggregateSerializer(RequireOneTranslationMixin,
             choices = [(i, str(i)) for i in range(minimum, maximum+1)]
         for value, label in choices:
             total = {'total': counts.get(value, 0)}
-            for lang, name in settings.LANGUAGES:
+            for lang, name in settings.FRONTEND_LANGUAGES:
                 with override(language=lang):
                     total['label_{}'.format(lang)] = force_text(label)
             totals.append(total)

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -45,11 +45,14 @@ TIME_ZONE = 'Asia/Beirut'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
+# LANGUAGES is only used in the Django admin
 LANGUAGES = [
     ('en', _('English')),
-    # Use only English for the Django Admin. Frontend will still be translated
-    # ('ar', _('Arabic')),
-    # ('fr', _('French')),
+]
+FRONTEND_LANGUAGES = [
+    ('en', _('English')),
+    ('ar', _('Arabic')),
+    ('fr', _('French')),
 ]
 
 # If you set this to False, Django will make some optimizations so as not

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -50,8 +50,8 @@ LANGUAGES = [
     ('en', _('English')),
 ]
 FRONTEND_LANGUAGES = [
-    ('en', _('English')),
     ('ar', _('Arabic')),
+    ('en', _('English')),
     ('fr', _('French')),
 ]
 

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -46,9 +46,10 @@ TIME_ZONE = 'Asia/Beirut'
 LANGUAGE_CODE = 'en-us'
 
 LANGUAGES = [
-    ('ar', _('Arabic')),
     ('en', _('English')),
-    ('fr', _('French')),
+    # Use only English for the Django Admin. Frontend will still be translated
+    # ('ar', _('Arabic')),
+    # ('fr', _('French')),
 ]
 
 # If you set this to False, Django will make some optimizations so as not

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -737,7 +737,7 @@ class LanguageTest(APITestMixin, TestCase):
         self.assertEqual(OK, rsp.status_code, msg=rsp.content.decode('utf-8'))
         result = json.loads(rsp.content.decode('utf-8'))
         self.assertEqual('', result['language'])
-        TEST_LANG = 'en'
+        TEST_LANG = 'fr'
         rsp = self.post_with_token(url, {'language': TEST_LANG})
         self.assertEqual(OK, rsp.status_code, msg=rsp.content.decode('utf-8'))
         rsp = self.get_with_token(url)

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -737,7 +737,7 @@ class LanguageTest(APITestMixin, TestCase):
         self.assertEqual(OK, rsp.status_code, msg=rsp.content.decode('utf-8'))
         result = json.loads(rsp.content.decode('utf-8'))
         self.assertEqual('', result['language'])
-        TEST_LANG = 'fr'
+        TEST_LANG = 'en'
         rsp = self.post_with_token(url, {'language': TEST_LANG})
         self.assertEqual(OK, rsp.status_code, msg=rsp.content.decode('utf-8'))
         rsp = self.get_with_token(url)


### PR DESCRIPTION
Addresses #45

I wasn't able to reproduce the issue though. I changed Chrome to set
Arabic as my preferred language, but the Admin still displayed in
English (while other sites, eg libyavotes.ly displayed in Arabic).

So I'm not 100% sure this is the right solution.