### PR TITLE
Use locale middleware and rearrange per Django docs

### DIFF
--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -123,8 +123,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 MIDDLEWARE_CLASSES = (
     'corsheaders.middleware.CorsMiddleware',
-    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',


### PR DESCRIPTION
Addresses #45 again.

LocaleMiddleware should come after SessionMiddleware and before CommonMiddleware:

https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#how-django-discovers-language-preference

I manually made this change on the server and it worked. The code which checks LANGUAGES is in LocaleMiddleware.

https://github.com/django/django/blob/master/django/middleware/locale.py#L24-L25
https://github.com/django/django/blob/master/django/utils/translation/trans_real.py#L473-L518