### PR TITLE
Allow long fields to wrap

### DIFF
--- a/service_info/static/css/admin_styles.css
+++ b/service_info/static/css/admin_styles.css
@@ -1,5 +1,0 @@
-/* Styles applied to Service admin pages */
-
-/* Hide time zone warnings; they're not relevant to bare times (no date) */
-.timezonewarning { display: none; }
-

--- a/service_info/static/css/service-admin.css
+++ b/service_info/static/css/service-admin.css
@@ -1,4 +1,12 @@
+/* Styles applied to Service admin pages */
+
+
+/* Hide time zone warnings; they're not relevant to bare times (no date) */
+.timezonewarning { display: none; }
+
+/* Django adds a nowrap class to FK fields, so that when you use them in a
+   `list_editable` declaration, the plus button doesn't wrap to the next line
+   after the dropdown. We're not using `list_editable` so it's OK if ours wrap. */
 td.nowrap {
-    /* Allow long fields to wrap in Services admin list */
     white-space: normal;
 }

--- a/service_info/static/css/service-admin.css
+++ b/service_info/static/css/service-admin.css
@@ -1,0 +1,4 @@
+td.nowrap {
+    /* Allow long fields to wrap in Services admin list */
+    white-space: normal;
+}

--- a/services/admin.py
+++ b/services/admin.py
@@ -131,8 +131,7 @@ class ServiceAdmin(AdminImageMixin, admin.ModelAdmin):
                     'area_of_service',
                     'show_image',
                     ]
-    list_editable = ['provider', ]
-    list_display_links = ['name_en', 'name_ar', 'name_fr', 'area_of_service']
+    list_display_links = ['name_en', 'name_ar', 'name_fr', 'provider', 'area_of_service']
     list_filter = ['status', 'type']
     readonly_fields = ['status']
 

--- a/services/admin.py
+++ b/services/admin.py
@@ -131,7 +131,8 @@ class ServiceAdmin(AdminImageMixin, admin.ModelAdmin):
                     'area_of_service',
                     'show_image',
                     ]
-    list_display_links = ['name_en', 'name_ar', 'name_fr', 'provider', 'area_of_service']
+    list_editable = ['provider', ]
+    list_display_links = ['name_en', 'name_ar', 'name_fr', 'area_of_service']
     list_filter = ['status', 'type']
     readonly_fields = ['status']
 

--- a/services/admin.py
+++ b/services/admin.py
@@ -74,6 +74,11 @@ class ServiceAdminForm(forms.ModelForm):
 
 
 class ServiceAdmin(AdminImageMixin, admin.ModelAdmin):
+    class Media:
+        css = {
+            "all": ("css/service-admin.css",)
+        }
+
     form = ServiceAdminForm
 
     actions = ['approve', 'reject']


### PR DESCRIPTION
This is the simplest fix. Allow long fields to wrap in the Services admin list
display.

Addresses #46