### PR TITLE
REST API browser authentication issue

### DIFF
--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -235,6 +235,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissions'
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
         'api.auth.ServiceInfoTokenAuthentication',
     ),
     # LimitOffsetPagination allows the caller to control pagination.

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -1,4 +1,5 @@
-from http.client import OK, CREATED, BAD_REQUEST, NOT_FOUND, METHOD_NOT_ALLOWED, UNAUTHORIZED
+from http.client import OK, CREATED, BAD_REQUEST, NOT_FOUND, METHOD_NOT_ALLOWED, UNAUTHORIZED, \
+    FORBIDDEN
 import json
 
 from django.contrib.auth import get_user_model, authenticate
@@ -310,7 +311,7 @@ class ProviderAPITest(APITestMixin, TestCase):
         ProviderFactory()
         url = reverse('provider-list')
         rsp = self.client.get(url)
-        self.assertEqual(UNAUTHORIZED, rsp.status_code, msg=rsp.content.decode('utf-8'))
+        self.assertEqual(FORBIDDEN, rsp.status_code, msg=rsp.content.decode('utf-8'))
 
     def test_get_one_provider(self):
         p1 = ProviderFactory(user=self.user)
@@ -324,7 +325,7 @@ class ProviderAPITest(APITestMixin, TestCase):
         p1 = ProviderFactory(user=self.user)
         url = reverse('provider-detail', args=[p1.id])
         rsp = self.client.get(url)
-        self.assertEqual(UNAUTHORIZED, rsp.status_code, msg=rsp.content.decode('utf-8'))
+        self.assertEqual(FORBIDDEN, rsp.status_code, msg=rsp.content.decode('utf-8'))
 
     def test_update_provider(self):
         p1 = ProviderFactory(user=self.user)

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -1,4 +1,4 @@
-from http.client import OK, CREATED, BAD_REQUEST, NOT_FOUND, METHOD_NOT_ALLOWED, UNAUTHORIZED, \
+from http.client import OK, CREATED, BAD_REQUEST, NOT_FOUND, METHOD_NOT_ALLOWED, \
     FORBIDDEN
 import json
 


### PR DESCRIPTION
I can see the API here: http://localhost:4005/api/ and there's a login button. But despite logging in as a superuser, some URLs still tell me I'm unauthorized:

http://localhost:4005/api/providers/
http://localhost:4005/api/services/

![image](https://cloud.githubusercontent.com/assets/4413/8835733/44c8c39c-308a-11e5-859c-27d2cd4ea1b8.png)

Other URLs seem to work:

http://localhost:4005/api/nationality/
http://localhost:4005/api/feedback/
