### PR TITLE
npm: Use commit hashes rather than git tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "hashtrack": "^1.0.2",
     "underscore": "^1.7.0",
     "jquery-form": "~3.50.0",
-    "OverlappingMarkerSpiderfier": "yagoferrer/OverlappingMarkerSpiderfier.git#0.3.3e",
-    "Flot": "flot/flot.git#v0.8.3"
-
+    "OverlappingMarkerSpiderfier": "yagoferrer/OverlappingMarkerSpiderfier#747476d7bf",
+    "Flot": "flot/flot#453b017cc5"
   },
   "devDependencies": {
     "closurecompiler": "^1.5.1",


### PR DESCRIPTION
Travis started failing on the `npm install` command today. Interestingly it fails locally as well (though I swear it worked just fine before). The complaints seem to be about the 2 packages in package.json which use git repos instead of the npm registry.

After some trial and error, changing those to use git commit hashes instead of git tags seems to work locally.

Unfortunately, there's no clean way to add comments in JSON files, otherwise I would have added the git tags as comments.