### PR TITLE
Only use npm packages from the registry

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -12,9 +12,9 @@ var _ = underscore;
 
 // Load Flot and 2 plugins (categories and stack)
 // http://www.flotcharts.org/
-require('Flot');
-require('Flot/jquery.flot.categories');
-require('Flot/jquery.flot.stack');
+require('jquery-flot');
+require('jquery-flot/jquery.flot.categories');
+require('jquery-flot/jquery.flot.stack');
 
 hashtrack.init();
 require('es6-promise').polyfill();

--- a/frontend/views/map.js
+++ b/frontend/views/map.js
@@ -4,9 +4,11 @@ var Backbone = require('backbone'),
     service = require('../models/service'),
     servicetype = require('../models/servicetype'),
     i18n = require('i18next-client'),
-    search = require('../search'),
-    spiderfier = require('OverlappingMarkerSpiderfier/oms')
+    search = require('../search')
 ;
+
+// required here because this is the only view that needs it
+require('marker-spider/dist/oms.min');
 
 
 module.exports = Backbone.View.extend({
@@ -53,7 +55,7 @@ module.exports = Backbone.View.extend({
         };
         this.map = new google.maps.Map(document.getElementById('map_canvas'), mapOptions);
 
-        this.spiderfier = new spiderfier.OverlappingMarkerSpiderfier(self.map);
+        this.spiderfier = new OverlappingMarkerSpiderfier(self.map);
         this.spiderfier.addListener('click', function(marker, event) {
             // User clicks on a limb of the spider. Go to that service
             location.hash = '#/service/' + marker.serviceId;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "hashtrack": "^1.0.2",
     "underscore": "^1.7.0",
     "jquery-form": "~3.50.0",
-    "OverlappingMarkerSpiderfier": "yagoferrer/OverlappingMarkerSpiderfier#747476d7bf",
-    "Flot": "flot/flot#453b017cc5"
+    "marker-spider": "0.1.0",
+    "jquery-flot": "0.8.3"
   },
   "devDependencies": {
     "closurecompiler": "^1.5.1",


### PR DESCRIPTION
Try as I might, I could not get github packages to work simultaneously locally and on staging. Therefore, I decided to make sure we only use packages from the NPM registry (npmjs.com).

I was able to find Flot on the registry, under the 'jquery-flot' name.

I manually uploaded 'marker-spiderfier' (a copy of OverlappingMarkerSpiderfier).

One of the issues may also have been that the names of the packages must begin with lowercase letter, so 'marker-spiderfier' is more legal than 'OverlappingMarkerSpiderfier'. (But I tried just changing that, and still failed, when using github specs alone).