### PR TITLE
Fix 403s from API form submission

### DIFF
--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -236,8 +236,8 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissions'
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.SessionAuthentication',
         'api.auth.ServiceInfoTokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ),
     # LimitOffsetPagination allows the caller to control pagination.
     # We won't paginate by default.

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -1,5 +1,4 @@
-from http.client import OK, CREATED, BAD_REQUEST, NOT_FOUND, METHOD_NOT_ALLOWED, \
-    FORBIDDEN
+from http.client import OK, CREATED, BAD_REQUEST, NOT_FOUND, METHOD_NOT_ALLOWED, UNAUTHORIZED
 import json
 
 from django.contrib.auth import get_user_model, authenticate
@@ -311,7 +310,7 @@ class ProviderAPITest(APITestMixin, TestCase):
         ProviderFactory()
         url = reverse('provider-list')
         rsp = self.client.get(url)
-        self.assertEqual(FORBIDDEN, rsp.status_code, msg=rsp.content.decode('utf-8'))
+        self.assertEqual(UNAUTHORIZED, rsp.status_code, msg=rsp.content.decode('utf-8'))
 
     def test_get_one_provider(self):
         p1 = ProviderFactory(user=self.user)
@@ -325,7 +324,7 @@ class ProviderAPITest(APITestMixin, TestCase):
         p1 = ProviderFactory(user=self.user)
         url = reverse('provider-detail', args=[p1.id])
         rsp = self.client.get(url)
-        self.assertEqual(FORBIDDEN, rsp.status_code, msg=rsp.content.decode('utf-8'))
+        self.assertEqual(UNAUTHORIZED, rsp.status_code, msg=rsp.content.decode('utf-8'))
 
     def test_update_provider(self):
         p1 = ProviderFactory(user=self.user)


### PR DESCRIPTION
This is a theoretical fix because I cannot reproduce the issue locally.

The issue occurs in this piece of code:
https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/authentication.py#L124-L128

If an anonymous user hits that code, then it's OK because authenticate will return None and not try to `enforce_csrf`.

If a logged-in user hits that code, then `enforce_csrf` will get hit and will fail. (That failure puzzles me, but I don't quite understand how CSRF validation is done in this project. I assume that it's different because of the client-API nature of it)

I think reversing the order of the authentication classes will work because DRF short circuits at the first class that succeeds. In the anonymous user case, both will fail, but that's OK, and `enforce_csrf` won't get hit. In the logged-in user case, TokenAuthentication will succeed, so the SessionAuthentication will not get hit at all.

Addresses #56