### PR TITLE
CSV Reports URL changed

### DIFF
--- a/frontend/views/reports.js
+++ b/frontend/views/reports.js
@@ -215,7 +215,7 @@ module.exports = Backbone.View.extend({
         e.preventDefault();
         var today = new Date(),
             filename = this.report + '-' + today.toISOString().replace(/\T.*$/, '') + '.csv';
-        api.request('GET', 'api/servicetypes/' + this.report + '/?format=csv')
+        api.request('GET', 'api/reports/' + this.report + '/?format=csv')
             .then(function (response) {
                 var blob = new Blob([response], {type: 'text/csv'}),
                     blobURL, link;


### PR DESCRIPTION
The URL for reports was changed from /servicetypes/ to /reports/ since reports
are not exclusively about servicetypes, but I forgot to change the Download
CSV link.