### PR TITLE
66 Fix feedback bugs

### DIFF
--- a/frontend/templates/feedback-form.hbs
+++ b/frontend/templates/feedback-form.hbs
@@ -167,7 +167,6 @@
                               <input type="radio" name="wait_time_satisfaction" class="form-control" value="{{ this }}">{{ this }}
                             </label>
                         {{/each}}
-                        <textarea id=id_other_difficulties rows="4" name="other_difficulties" class="form-control"></textarea>
                       </div>
                     </div>
                   </div>
@@ -189,9 +188,6 @@
                           <option value="unfair" data-i18n="Feedback-Form.non-delivery-explanation.unfair"></option>
                           <option value="yes" data-i18n="Feedback-Form.non-delivery-explanation.yes"></option>
                       </select>
-                      <label for="id_extra_comments" class="control-label"><span  data-i18n="Feedback-Form.extra-comments"></span></label>
-                      <span class=error></span>
-                      <textarea id=id_extra_comments rows="4" name="extra_comments" class="form-control"></textarea>
                     </div>
                   </div>
                 </div>
@@ -199,6 +195,7 @@
               </div>
             </div>
 
+            {{!-- difficulty contacting? }}
             {{!-- whether delivered or not --}}
             <div class="row">
               <div class="form-group">
@@ -217,27 +214,27 @@
                   </select>
                 </div>
               </div>
-                <div class="half"></div>
+              <div class="half"></div>
             </div>
-            </div>
+          </div>
 
             {{!-- this only displayed if answer to previous question is 'other' --}}
             <div class="row" id="row_other_difficulties">
               <div class="form-group">
-                <label for="id_other_difficulties" class="control-label"><span data-i18n="Feedback-Form.other_difficulties"></span>></label>
+                <label for="id_other_difficulties" class="control-label"><span data-i18n="Feedback-Form.other-difficulties"></span></label>
                 <div class="form-group">
                   <span class=error></span>
-                  <textarea id=id_other_difficulties rows="4" name="other_difficulties" data-i18n-field class="form-control"></textarea>
+                  <textarea id=id_other_difficulties rows="4" name="other_difficulties" class="form-control"></textarea>
                 </div>
               </div>
             </div>
 
             <div class=row>
               <div class="form-group">
-                <label for="id_extra_comments" class="control-label"><span data-i18n="Feedback-Form.extra_comments"></span></label>
+                <label for="id_extra_comments" class="control-label"><span data-i18n="Feedback-Form.extra-comments"></span></label>
                 <div class="form-group">
                   <span class=error></span>
-                  <textarea id=id_extra_comments rows="4" name="extra_comments" data-i18n-field class="form-control"  ></textarea>
+                  <textarea id=id_extra_comments rows="4" name="extra_comments" class="form-control"  ></textarea>
                 </div>
               </div>
             </div>

--- a/frontend/views/feedback-form.js
+++ b/frontend/views/feedback-form.js
@@ -62,7 +62,7 @@ module.exports = Backbone.View.extend({
         $('.ifdelivered, .ifnotdelivered, #row_other_difficulties').hide();
 
         // Don't allow submit until they've said if the service was delivered
-        $('button.form-btn-submit').hide()
+        $('button.form-btn-submit').hide();
     },
 
     events: {
@@ -71,7 +71,7 @@ module.exports = Backbone.View.extend({
             $('.hideuntildelivered').show();
             $('.ifdelivered').toggle(delivered);
             $('.ifnotdelivered').toggle(!delivered);
-            $('button.form-btn-submit').show()
+            $('button.form-btn-submit').show();
         },
         "change [name=difficulty_contacting]": function() {
             var difficulty = $("#id_difficulty_contacting option:selected").val();
@@ -83,7 +83,7 @@ module.exports = Backbone.View.extend({
                 el: this.$el,
                 url: 'api/feedback/',
                 next_location: '#/feedback/confirm'
-            })
+            });
         },
         "click .form-btn-clear": function(e) {
             e.preventDefault();

--- a/service_info/tests/test_feedback.py
+++ b/service_info/tests/test_feedback.py
@@ -106,4 +106,4 @@ class FeedbackTest(ServiceInfoFrontendTestCase):
         self.assertEqual('Other difficulties', feedback.other_difficulties)
         self.assertEqual(2, feedback.staff_satisfaction)
         self.assertEqual('Other comments', feedback.extra_comments)
-        self.assertEqual(True, feedback.anonymouse)
+        self.assertEqual(True, feedback.anonymous)

--- a/service_info/tests/test_feedback.py
+++ b/service_info/tests/test_feedback.py
@@ -1,11 +1,8 @@
-import time
 from selenium.common.exceptions import TimeoutException, WebDriverException
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.wait import WebDriverWait
+from service_info.tests.test_frontend import ServiceInfoFrontendTestCase
 
-from service_info.tests.test_frontend import ServiceInfoFrontendTestCase, DEFAULT_TIMEOUT
 from services.models import Service, Nationality, ServiceArea, Feedback
 from services.tests.factories import ServiceFactory
 
@@ -41,7 +38,8 @@ class FeedbackTest(ServiceInfoFrontendTestCase):
 
         def type_in_element(selector, text):
             try:
-                self.wait_for_element(selector, match=By.CSS_SELECTOR, must_be_visible=True).send_keys(text)
+                self.wait_for_element(selector, match=By.CSS_SELECTOR,
+                                      must_be_visible=True).send_keys(text)
             except TimeoutException:
                 print("Timeout waiting for %s to appear, continuing anyway" % selector)
 
@@ -56,7 +54,8 @@ class FeedbackTest(ServiceInfoFrontendTestCase):
         click_element('input[name=delivered][value="1"]')
 
         # Wait for javascript to display the "delivered" fields
-        self.wait_for_element('input[name=quality][value="4"]', match=By.CSS_SELECTOR, must_be_visible=True)
+        self.wait_for_element('input[name=quality][value="4"]', match=By.CSS_SELECTOR,
+                              must_be_visible=True)
 
         click_element('input[name=quality][value="4"]')
         click_element('input[name=staff_satisfaction][value="2"]')
@@ -64,7 +63,8 @@ class FeedbackTest(ServiceInfoFrontendTestCase):
         click_element('input[name=wait_time_satisfaction][value="1"]')
         click_element('select[name=difficulty_contacting] option[value=other]')
         # Wait for JS again
-        self.wait_for_element('textarea[name=other_difficulties]', match=By.CSS_SELECTOR, must_be_visible=True)
+        self.wait_for_element('textarea[name=other_difficulties]', match=By.CSS_SELECTOR,
+                              must_be_visible=True)
         type_in_element('textarea[name=other_difficulties]', 'Other difficulties')
 
         type_in_element('textarea[name=extra_comments]', 'Other comments')
@@ -72,7 +72,7 @@ class FeedbackTest(ServiceInfoFrontendTestCase):
         self.browser.get_screenshot_as_file("pre_submit.png")
 
         # Submit
-        submit_button = self.wait_for_element('button.form-btn-submit', match=By.CSS_SELECTOR).click()
+        self.wait_for_element('button.form-btn-submit', match=By.CSS_SELECTOR).click()
 
         # Wait
         try:

--- a/service_info/tests/test_feedback.py
+++ b/service_info/tests/test_feedback.py
@@ -1,0 +1,109 @@
+import time
+from selenium.common.exceptions import TimeoutException, WebDriverException
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.wait import WebDriverWait
+
+from service_info.tests.test_frontend import ServiceInfoFrontendTestCase, DEFAULT_TIMEOUT
+from services.models import Service, Nationality, ServiceArea, Feedback
+from services.tests.factories import ServiceFactory
+
+
+class FeedbackTest(ServiceInfoFrontendTestCase):
+
+    def test_feedback_page_delivered(self):
+        self.assertFalse(Feedback.objects.all().exists())
+
+        service = ServiceFactory(status=Service.STATUS_CURRENT)
+        self.load_page_and_set_language()
+        menu = self.wait_for_element('menu')
+        feedback = menu.find_elements_by_link_text('Give Feedback')[0]
+        feedback.click()
+        form = self.wait_for_element('search_controls')
+        self.assertHashLocation('/feedback/list')
+        service_name = self.wait_for_element(
+            'a[href="#/service/%d"]' % service.id, match=By.CSS_SELECTOR)
+        service_name.click()
+
+        feedback_button = self.wait_for_element(
+            'a[href="#/feedback/%d"] button' % service.id,
+            match=By.CSS_SELECTOR)
+        feedback_button.click()
+
+        self.wait_for_element('input[name=anonymous]', match=By.CSS_SELECTOR)
+
+        # Fill in the form
+        form = self.wait_for_element('form', match=By.CSS_SELECTOR)
+
+        def click_element(selector):
+            form.find_element(value=selector, by=By.CSS_SELECTOR).click()
+
+        def type_in_element(selector, text):
+            try:
+                self.wait_for_element(selector, match=By.CSS_SELECTOR, must_be_visible=True).send_keys(text)
+            except TimeoutException:
+                print("Timeout waiting for %s to appear, continuing anyway" % selector)
+
+        type_in_element('[name=name]', 'John Doe')
+        type_in_element('[name=phone_number]', '12-345678')
+        iraqi_nationality = Nationality.objects.get(name_en='Iraqi')
+        click_element('select[name=nationality] option[value$="/%d/"]' % iraqi_nationality.id)
+
+        area = ServiceArea.objects.first()
+        click_element('select[name=area_of_residence] option[value$="/%d/"]' % area.id)
+        click_element('input[name=anonymous][value="1"]')
+        click_element('input[name=delivered][value="1"]')
+
+        # Wait for javascript to display the "delivered" fields
+        self.wait_for_element('input[name=quality][value="4"]', match=By.CSS_SELECTOR, must_be_visible=True)
+
+        click_element('input[name=quality][value="4"]')
+        click_element('input[name=staff_satisfaction][value="2"]')
+        click_element('select[name=wait_time] option[value="3-7days"]')
+        click_element('input[name=wait_time_satisfaction][value="1"]')
+        click_element('select[name=difficulty_contacting] option[value=other]')
+        # Wait for JS again
+        self.wait_for_element('textarea[name=other_difficulties]', match=By.CSS_SELECTOR, must_be_visible=True)
+        type_in_element('textarea[name=other_difficulties]', 'Other difficulties')
+
+        type_in_element('textarea[name=extra_comments]', 'Other comments')
+
+        self.browser.get_screenshot_as_file("pre_submit.png")
+
+        # Submit
+        submit_button = self.wait_for_element('button.form-btn-submit', match=By.CSS_SELECTOR).click()
+
+        # Wait
+        try:
+            self.wait_for_element('a[href="#/feedback/list"]', match=By.CSS_SELECTOR)
+        except WebDriverException as e:
+            self.browser.get_screenshot_as_file("screenshot.png")
+            print("ERROR waiting for feedback confirmation page, ignoring for now.")
+            print("Screenshot in screenshot.png")
+            print(e)
+
+        self.browser.get_screenshot_as_file("post_submit.png")
+
+        # Did we get a Feedback object?
+        if not Feedback.objects.exists():
+            self.fail("SOME error occurred, see screenshots pre_submit.png and post_submit.png")
+
+        # Find the submitted form
+        self.assertEqual(1, Feedback.objects.all().count())
+        feedback = Feedback.objects.first()
+        self.assertEqual('John Doe', feedback.name)
+        self.assertEqual('12-345678', feedback.phone_number)
+        self.assertEqual(iraqi_nationality, feedback.nationality)
+        self.assertEqual(area, feedback.area_of_residence)
+        self.assertEqual(service, feedback.service)
+        self.assertEqual(True, feedback.delivered)
+        self.assertEqual(4, feedback.quality)
+        self.assertFalse(feedback.non_delivery_explained)
+        self.assertEqual('3-7days', feedback.wait_time)
+        self.assertEqual(1, feedback.wait_time_satisfaction)
+        self.assertEqual('other', feedback.difficulty_contacting)
+        self.assertEqual('Other difficulties', feedback.other_difficulties)
+        self.assertEqual(2, feedback.staff_satisfaction)
+        self.assertEqual('Other comments', feedback.extra_comments)
+        self.assertEqual(True, feedback.anonymouse)


### PR DESCRIPTION
* Fix spelling of names of some translated text messages that
  was resulting in some labels not appearing
* Remove 'data-i18n-field' attribute from some input fields.
  That attribute tells our code that those fields are translated,
  so we were submitting them with "_en" appended to their names.
  In fact they aren't translated so we ignored those fields that
  were being submitted with the wrong names.
* Remove a rogue ">".
* Remove extra copy of the "other_difficulties" input.
* Remove extra copy of the "extra_comments" input.

Fixes #66