### PR TITLE
Changing gulp-less requirement version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp": "^3.8.10",
     "gulp-bg": "0.0.5",
     "gulp-browserify": "^0.5.1",
-    "gulp-less": "^2.0.1",
+    "gulp-less": "^3.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-util": "^3.0.4",
     "i18next-conv": "^0.1.4",


### PR DESCRIPTION
There's a bug with 2.* versions of gulp-less that was preventing me from being able to build. Requiring version 3 and up fixes this.