### PR TITLE
CMS front-end build process and mobile menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ frontend/bundle_min.js
 frontend/styles/site.css
 frontend/styles/site-ltr.css
 frontend/styles/site-rtl.css
+service_info/static/js/dist/
+service_info/static/css/site.css
 node_modules
 bundle_min.js
 feedback-help.hbs

--- a/service_info/static/js/src/component/menu.js
+++ b/service_info/static/js/src/component/menu.js
@@ -1,0 +1,13 @@
+var $ = require('jquery');
+window.jQuery = $;
+window.$ = $;
+
+var menu = require('../config').components.menu;
+
+function init () {
+    $(menu.toggle).click(function() {
+        $(menu.container).toggleClass([menu.closed_class, menu.open_class].join(' '));
+    });
+}
+
+module.exports = init;

--- a/service_info/static/js/src/config.js
+++ b/service_info/static/js/src/config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    components: {
+        menu: {
+            toggle: '#menu-toggle'
+            , container: '#menu-container'
+            , closed_class: 'menu-closed'
+            , open_class: 'menu-open'
+        }
+    }
+};

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -1,0 +1,3 @@
+var menu = require('./component/menu.js');
+
+menu();

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -1,3 +1,3 @@
-var menu = require('./component/menu.js');
+var menu = require('./component/menu');
 
 menu();

--- a/service_info/static/less/site.less
+++ b/service_info/static/less/site.less
@@ -1,3 +1,8 @@
 /*
 *   Site Styles
 */
+
+@import "base.less";
+@import "content-types/faq.less";
+@import "content-types/full-width-image.less";
+@import "content-types/pages-index.less";

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -8,7 +8,7 @@
 
         <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" />
         <link rel="stylesheet" href="{% if request.LANGUAGE_CODE == 'ar' %}{% static 'styles/site-rtl.css' %}{% else %}{% static 'styles/site-ltr.css' %}{% endif %}" type="text/css" class="load-style"/>
-        <link rel="stylesheet" href="{% static 'less/base.less' %}" type="text/less">
+        <link rel="stylesheet" href="{% static 'css/site.css' %}" type="text/css">
         {% render_block "css" %}
 
         <link rel="shortcut icon" href="{% static 'images/sm-favicon.png' %}">
@@ -79,7 +79,6 @@
             <div id="report-tooltip"></div>
         </div>
 
-        <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.5.1/less.min.js"></script>
         <script src="{% static 'js/dist/bundle.js' %}"></script>
         {% render_block "js" %}
     </body>

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -80,6 +80,7 @@
         </div>
 
         <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.5.1/less.min.js"></script>
+        <script src="{% static 'js/dist/bundle.js' %}"></script>
         {% render_block "js" %}
     </body>
 </html>

--- a/service_info/templates/cms/content-types/faq.html
+++ b/service_info/templates/cms/content-types/faq.html
@@ -2,10 +2,6 @@
 {% load cms_tags sekizai_tags staticfiles %}
 
 {% block content %}
-    {% addtoblock "css" %}
-        <link rel="stylesheet" type="text/less" media="all" href="{% static 'less/content-types/faq.less' %}">
-    {% endaddtoblock %}
-    
     <ul id="faq">
         {% for qa in qas %}
             <li class="qa">

--- a/service_info/templates/cms/content-types/full-width-image.html
+++ b/service_info/templates/cms/content-types/full-width-image.html
@@ -4,9 +4,5 @@
 {% block content-class %}full-width-image{% endblock content-class %}
 
 {% block content %}
-    {% addtoblock "css" %}
-        <link rel="stylesheet" type="text/less" media="all" href="{% static 'less/content-types/full-width-image.less' %}">
-    {% endaddtoblock %}
-    
     {% placeholder "content" %}
 {% endblock content %}

--- a/service_info/templates/cms/content-types/pages-index.html
+++ b/service_info/templates/cms/content-types/pages-index.html
@@ -2,9 +2,6 @@
 {% load cms_tags sekizai_tags staticfiles %}
 
 {% block content %}
-    {% addtoblock "css" %}
-        <link rel="stylesheet" type="text/less" media="all" href="{% static 'less/content-types/pages-index.less' %}">
-    {% endaddtoblock %}
     <ul id="pages">
         {% for page in pages %}
             <li class="page">


### PR DESCRIPTION
Two big changes:

* Modifying the Gulp setup so that the CMS side of Service Info will have a proper Less and JS build process.
* Adding code to initialize the menu interactivity on the CMS.

To verify that it works, check out the branch, run `gulp`, look at the CMS on mobile emulation view, and verify that clicking the menu button exposes the menu.