### PR TITLE
SC-27 - add Disqus to cms

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,3 +43,4 @@ cmsplugin-filer==0.10.2
   django-appconf==1.0.1
 djangocms-text-ckeditor==2.7.0
 django-reversion==1.8.5
+aldryn-disqus==1.0.0

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -230,6 +230,7 @@ INSTALLED_APPS = (
     'cmsplugin_filer_image',
     'cmsplugin_filer_teaser',
     'cmsplugin_filer_video',
+    'aldryn_disqus',
     # End Django CMS
     # Load after easy_thumbnails so that its thumbnail template tag (unused
     # in this project) is hidden.
@@ -411,3 +412,4 @@ THUMBNAIL_HIGH_RESOLUTION = True
 TEXT_SAVE_IMAGE_FUNCTION = 'cmsplugin_filer_image.integrations.ckeditor.create_image_plugin'
 
 CMS_APP_NAME = 'cms'
+DISQUS_SHORTNAME = 'trawicktestsites'  # allowed only on localhost

--- a/service_info/settings/production.py
+++ b/service_info/settings/production.py
@@ -11,7 +11,7 @@ DEFAULT_FROM_EMAIL = 'noreply@rescue.org'
 SITE_ID = PRODUCTION_SITE_ID
 
 CMS_LANGUAGES[SITE_ID] = CMS_LANGUAGES_FOR_SITE
-DISQUS_SHORTNAME = 'not-yet-created'
+DISQUS_SHORTNAME = 'serviceinfo'
 
 # Uncomment if using celery worker configuration
 if 'BROKER_PASSWORD' in os.environ:

--- a/service_info/settings/production.py
+++ b/service_info/settings/production.py
@@ -11,6 +11,7 @@ DEFAULT_FROM_EMAIL = 'noreply@rescue.org'
 SITE_ID = PRODUCTION_SITE_ID
 
 CMS_LANGUAGES[SITE_ID] = CMS_LANGUAGES_FOR_SITE
+DISQUS_SHORTNAME = 'not-yet-created'
 
 # Uncomment if using celery worker configuration
 if 'BROKER_PASSWORD' in os.environ:

--- a/service_info/settings/staging.py
+++ b/service_info/settings/staging.py
@@ -39,6 +39,7 @@ ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(';')
 SITE_ID = STAGING_SITE_ID
 
 CMS_LANGUAGES[SITE_ID] = CMS_LANGUAGES_FOR_SITE
+DISQUS_SHORTNAME = 'not-yet-created'
 
 # Uncomment if using celery worker configuration
 if 'BROKER_PASSWORD' in os.environ:

--- a/service_info/settings/staging.py
+++ b/service_info/settings/staging.py
@@ -39,7 +39,7 @@ ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(';')
 SITE_ID = STAGING_SITE_ID
 
 CMS_LANGUAGES[SITE_ID] = CMS_LANGUAGES_FOR_SITE
-DISQUS_SHORTNAME = 'not-yet-created'
+DISQUS_SHORTNAME = 'serviceinfo-staging'
 
 # Uncomment if using celery worker configuration
 if 'BROKER_PASSWORD' in os.environ:


### PR DESCRIPTION
Developers: Use "localhost" to be able to use my "trawicktestsites" Disqus site, and let me know if it appears to need some maintenance.

This configures the "serviceinfo-staging" Disqus site that Omar reported for staging, and tentatively uses "serviceinfo" for production.
