### PR TITLE
Work around this deploy issue:

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,7 +72,8 @@ git+git://github.com/caktus/aldryn-faq.git@1.0.7-146#egg=aldryn-faq
       # Unidecode
   django-admin-sortable==2.0.5
   # Has bug that breaks rich text editing of questions: django-admin-sortable2==0.6.0
-  git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50#egg=django-admin-sortable2
+  # Fails to deploy due to Unicode issue: git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50#egg=django-admin-sortable2
+  git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50-unicode#egg=django-admin-sortable2
   django-parler==1.5.1
   # django-reversion
   django-sortedm2m==1.0.2


### PR DESCRIPTION
```
Collecting django-admin-sortable2 from git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50#egg=django-admin-sortable2 (from -r /var/www/service_info/source/requirements/base.txt (line 52))
  Cloning git://github.com/caktus/django-admin-sortable2.git (to 0.6.0-50) to /tmp/pip-build-2cwtq1rk/django-admin-sortable2
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-2cwtq1rk/django-admin-sortable2/setup.py", line 33, in <module>
        long_description=convert('README.md', 'rst'),
      File "/tmp/pip-build-2cwtq1rk/django-admin-sortable2/setup.py", line 11, in convert
        return fd.read()
      File "/var/www/service_info/env/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 746: ordinal not in range(128)

    ---------------------------------------- Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-2cwtq1rk/django-admin-sortable2
```

We don't know at this time why that would need to use an ascii codec. A Jira ticket will be opened to resolve that issue permanently.

The work-around was to remove Unicode characters from README.md in our existing fork of django-admin-sortable2, and point to a new tag in the requirements for this project.