### PR TITLE
Adding language picker

### DIFF
--- a/frontend/templates/language-toggle.hbs
+++ b/frontend/templates/language-toggle.hbs
@@ -1,3 +1,3 @@
 <div class=language-toggle>
-    <button class="primary-button" data-lang="en">English</button><button class="primary-button" data-lang="fr">Fran&#xE7;ais</button><button class="primary-button lang-btn-ar" data-lang="ar">&#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;</button>
+    <button class="primary-button" data-lang="en">English</button><button class="primary-button lang-btn-ar" data-lang="ar">&#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;</button><button class="primary-button" data-lang="fr">Fran&#xE7;ais</button>
 </div>

--- a/service_info/static/js/src/component/language-toggle.js
+++ b/service_info/static/js/src/component/language-toggle.js
@@ -1,0 +1,47 @@
+var $ = require('jquery');
+window.jQuery = $;
+window.$ = $;
+var lt = require('../config').components.language_toggle;
+
+function init () {
+  var $toggle = $(lt.root);
+  var $shower = $(lt.shower);
+
+  function show () {
+    var curPos = $toggle.position();
+    $toggle
+      .css('visibility', 'hidden')
+      .removeClass('hidden')
+      .css({
+          top: 'auto'
+          , left: 'auto'
+      })
+      ;
+
+    var anim = $toggle.position();
+
+    $toggle
+      .addClass('hidden')
+      .css(curPos)
+      .css('visibility', 'visible')
+      .animate(anim, {duration: 0.5, complete: function () {
+          $toggle.css({
+              top: '0px'
+              , left: 'auto'
+          });
+      }})
+      .removeClass('hidden')
+      ;
+      
+    setTimeout(function () {
+        $toggle.removeClass('no-animate');
+    }, 0);
+  }
+
+  $shower.click(function (e) {
+    e.preventDefault();
+    show();
+  });
+}
+
+module.exports = init;

--- a/service_info/static/js/src/config.js
+++ b/service_info/static/js/src/config.js
@@ -6,5 +6,9 @@ module.exports = {
             , closed_class: 'menu-closed'
             , open_class: 'menu-open'
         }
+        , language_toggle: {
+            root: '#language-toggle'
+            , shower: '#language-chooser'
+        }
     }
 };

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -6,6 +6,7 @@
   Mobile menu show/hide
 */
 require('./component/menu')();
+require('./component/language-toggle')();
 
 /*
   Initializing Google Analytics

--- a/service_info/static/less/includes/header.less
+++ b/service_info/static/less/includes/header.less
@@ -139,6 +139,10 @@
                 height: 100%;
             }
 
+            &#language-chooser {
+                padding: 12px;
+            }
+
             &.parent > ul {
                 position: absolute;
                 top: 100%;

--- a/service_info/static/less/includes/header.less
+++ b/service_info/static/less/includes/header.less
@@ -141,6 +141,7 @@
 
             &#language-chooser {
                 padding: 12px;
+                cursor: pointer;
             }
 
             &.parent > ul {

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -75,7 +75,9 @@
                 </div>
                 {% endblock footer %}
             </div>
-            <div id="language-toggle" class="language-toggle modal-bg hidden"></div>
+
+            {% language_chooser "cms/includes/language-chooser.html" %}
+
             <div id="report-tooltip"></div>
         </div>
 

--- a/service_info/templates/cms/includes/language-chooser.html
+++ b/service_info/templates/cms/includes/language-chooser.html
@@ -1,0 +1,21 @@
+{% load cms_tags menu_tags %}
+
+<div id="language-toggle" class="language-toggle modal-bg hidden">
+  <div class=language-toggle>
+    {% for language in languages %}
+      <a href="{% page_language_url language.0 %}" class="{% ifequal lang language.0 %}current{% endifequal %}">
+        <button class="primary-button">
+          {% if language.0 == "ar" %}
+            &#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;
+          {% elif language.0 == "fr" %}
+            Français
+          {% elif language.0 == "en" %}
+            English
+          {% else %}
+            {{ language.0 }}
+          {% endif %}
+        </button>
+      </a>
+    {% endfor %}
+  </div>
+</div>

--- a/service_info/templates/cms/includes/menu.html
+++ b/service_info/templates/cms/includes/menu.html
@@ -1,5 +1,8 @@
-{% load menu_tags %}
+{% load menu_tags i18n %}
 
 {% for child in children %}
     <li><a href="{{ child.get_absolute_url }}">{{ child.get_menu_title }}</a></li>
 {% endfor %}
+<li id="language-chooser">
+    {% trans "Change language" %}
+</li>

--- a/service_info/templates/cms/includes/menu.html
+++ b/service_info/templates/cms/includes/menu.html
@@ -17,6 +17,9 @@
         {% endif %}
     </li>
 {% endfor %}
-<li id="language-chooser">
-    {% trans "Change language" %}
-</li>
+
+{% if not child.children %}
+    <li id="language-chooser">
+        {% trans "Change language" %}
+    </li>
+{% endif %}


### PR DESCRIPTION
As it turns out, it's pretty simple to switch between languages in django-cms. It is simply a matter of navigating to the equivalent URL on the other language's section. django-cms's language-picker template tag gives you an easy way to do this, supplying a `languages` context value that you can iterate over.

This adds:

* a permanent "Change Language" item in the nav menu
* a language-toggle widget in the base template (hidden by default)
* templates which attach links in the widget to the appropriate pages
* code to hook the Change Language item to the widget, revealing it

This "just works" in the sense that navigating to the proper CMS page sets the cookie to remember the language you were just on.