### PR TITLE
Making footer a static placeholder

### DIFF
--- a/service_info/static/js/src/component/footer.js
+++ b/service_info/static/js/src/component/footer.js
@@ -1,0 +1,29 @@
+var $ = require('jquery');
+var page = require('../config').components.page;
+var footer = require('../config').components.footer;
+
+/*
+  On the CMS, the footer needs to be allowed to grow arbitrarily tall.
+  The problem with this is that the page well also needs to have its bottom
+  padding adjusted to match the height of the footer.
+
+  The solution is to re-pad the content well on page load and whenever the
+  window is resized or reoriented.
+*/
+
+function init () {
+  var $page = $(page.container);
+  var $footer = $(footer.container);
+
+  resize($page, $footer);
+
+  $(window).on('resize reorient', function () { resize($page, $footer); });
+}
+
+function resize ($page, $footer) {
+  $page.css({
+    'padding-bottom': $footer.outerHeight() + 'px'
+  });
+}
+
+module.exports = init;

--- a/service_info/static/js/src/component/menu.js
+++ b/service_info/static/js/src/component/menu.js
@@ -1,7 +1,4 @@
 var $ = require('jquery');
-window.jQuery = $;
-window.$ = $;
-
 var menu = require('../config').components.menu;
 
 function init () {

--- a/service_info/static/js/src/config.js
+++ b/service_info/static/js/src/config.js
@@ -6,5 +6,11 @@ module.exports = {
             , closed_class: 'menu-closed'
             , open_class: 'menu-open'
         }
+        , page: {
+            container: '#page-container'
+        }
+        , footer: {
+            container: '#footer'
+        }
     }
 };

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -1,3 +1,7 @@
+var $ = require('jquery');
+window.jQuery = $;
+window.$ = $;
+
 /*
   UI COMPONENTS
 */
@@ -6,6 +10,11 @@
   Mobile menu show/hide
 */
 require('./component/menu')();
+
+/*
+  Set up footer
+*/
+require('./component/footer')();
 
 /*
   Initializing Google Analytics

--- a/service_info/static/less/includes/footer.less
+++ b/service_info/static/less/includes/footer.less
@@ -1,4 +1,58 @@
+@import "./mixins.less";
+
 #footer {
+  max-height: initial;
+  height: auto;
+
+  .row {
+    .flex-layout();
+    .flex-direction(row);
+    .flex-wrap(wrap);
+    .justify-content(flex-start);
+    .align-items(baseline);
+
+    max-width: initial;
+
+    > .cms_placeholder {
+      .flex(0, 0, 0);
+    }
+
+    > *:not(.cms_placeholder) {
+      padding-right: 2em;
+      box-sizing: border-box;
+
+      .flex(0, 0, 100%);
+    }
+
+    .cms_plugin {
+      color: white;
+
+      &.third {
+        .flex(0, 1, 33%);
+      }
+
+      &.two-thirds {
+        .flex(0, 1, 66%);
+      }
+
+      h2 {
+        font-style: normal !important;
+        margin-bottom: 4px;
+        line-height: 1.3em;
+        color: white;
+        font-weight: 700;
+      }
+
+      p {
+        margin-top: 0;
+      }
+
+      * {
+        color: inherit;
+      }
+    }
+  }
+
   @media (min-width: 640px) {
     width: 100%;
     margin-left: 0;
@@ -6,5 +60,13 @@
     margin-top: 0;
     padding: 20px;
     box-sizing: border-box;
+
+    .row {
+      .flex-wrap(nowrap);
+
+      > *:not(.cms_placeholder) {
+        .flex(0, 1, auto);
+      }
+    }
   }
 }

--- a/service_info/static/less/includes/footer.less
+++ b/service_info/static/less/includes/footer.less
@@ -6,10 +6,17 @@
 
   .row {
     .flex-layout();
-    .flex-direction(row);
     .flex-wrap(wrap);
     .justify-content(flex-start);
     .align-items(baseline);
+
+    & when (@direction = rtl) {
+      .flex-direction(row-reverse);
+    }
+
+    & when (@direction = ltr) {
+      .flex-direction(row);
+    }
 
     max-width: initial;
 

--- a/service_info/static/less/includes/footer.less
+++ b/service_info/static/less/includes/footer.less
@@ -3,12 +3,23 @@
 #footer {
   max-height: initial;
   height: auto;
+  position:relative;
 
   .row {
     .flex-layout();
     .flex-wrap(wrap);
     .justify-content(flex-start);
     .align-items(baseline);
+
+    .cms_placeholder {
+      width: 100%;
+      /*
+        This fixes a weird display glitch.
+
+        Seemingly placeholder elements behave strangely when embedded
+        in a flex-layout container.
+      */
+    }
 
     & when (@direction = rtl) {
       .flex-direction(row-reverse);
@@ -19,10 +30,6 @@
     }
 
     max-width: initial;
-
-    > .cms_placeholder {
-      .flex(0, 0, 0);
-    }
 
     > *:not(.cms_placeholder) {
       padding-right: 2em;

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -44,34 +44,7 @@
             <div id="footer">
                 {% block footer %}
                 <div class="row">
-                    <div id="about-si" class="two-third">
-                        <div class="page-title">{% trans "About ServiceInfo" %}</div>
-                        <div class="page-descr">
-                          <span class="sentence1">{% trans "Powered by the International Rescue Committee." %}</span>
-                          <span>{% trans "ServiceInfo is a tool that allows both service providers to register their services online and beneficiaries to both discover those services on a map and give feedback on them. ServiceInfo is open source and free to use." %}</span>
-                        </div>
-                    </div>
-                    <div id="contact-si" class="third">
-                        <div class="page-title">{% trans "Reach Us" %}</div>
-                        <div class="page-descr">{% trans "Contact us on one of our social networks below or drop us a mail at" %}</div>
-                        <div id="contact-icons">
-                            <div class="icon">
-                                <a href="mailto:serviceinfo@rescue.org">
-                                    <img src="{% static 'images/mail.svg' %}" alt="email link">
-                                </a>
-                            </div>
-                            <div class="icon">
-                                <a href="https://www.facebook.com/serviceinfolb">
-                                    <img src="{% static 'images/fbimage.svg' %}" alt="facebook link">
-                                </a>
-                            </div>
-                            <div class="icon">
-                                <a href="https://twitter.com/serviceinfolb">
-                                    <img src="{% static 'images/twimage.svg' %}" alt="twitter link">
-                                </a>
-                            </div>
-                        </div>
-                    </div>
+                    {% static_placeholder "footer" %}
                 </div>
                 {% endblock footer %}
             </div>


### PR DESCRIPTION
This converts the footer from a fixed-content element to a static placeholder (a placeholder item that, once published, is the same across all page types).

The footer's content objects are `flex: 0 1 auto` elements in a `flex-direction:row` container; they are `flex:0 0 100%` on mobile view so that the box collapses the row into a column.

Any of the usual content can be added to the footer.