### PR TITLE
Adding max-width to all blog images

### DIFF
--- a/service_info/static/less/content-types/blog/pages/base.less
+++ b/service_info/static/less/content-types/blog/pages/base.less
@@ -20,4 +20,8 @@
   > .aldryn-newsblog-list > h2 {
   }
 
+  img {
+    max-width: 100%;
+  }
+
 }

--- a/service_info/static/less/content-types/blog/pages/includes/article.less
+++ b/service_info/static/less/content-types/blog/pages/includes/article.less
@@ -8,10 +8,6 @@
         border: none;
       }
     }
-
-    img {
-      max-width: 100%;
-    }
   }
 
   p.category {


### PR DESCRIPTION
This oughta ensure that no image overflows its container ever again. No newsblog image, anyway.