### PR TITLE
Revising appearance of error messages

### DIFF
--- a/frontend/forms.js
+++ b/frontend/forms.js
@@ -181,7 +181,7 @@ var forms = module.exports = {
         if (e.status >= 500) {
             $('.error-submission').text(i18n.t('Global.FormSubmissionError'));
         } else if (e.status === 400) {
-            messages.add(i18n.t('Global.FormValidationError'));
+            //messages.add(i18n.t('Global.FormValidationError'));
         }
         return missing;
     },

--- a/frontend/forms.js
+++ b/frontend/forms.js
@@ -181,7 +181,7 @@ var forms = module.exports = {
         if (e.status >= 500) {
             $('.error-submission').text(i18n.t('Global.FormSubmissionError'));
         } else if (e.status === 400) {
-            //messages.add(i18n.t('Global.FormValidationError'));
+            messages.add(i18n.t('Global.FormValidationError'));
         }
         return missing;
     },

--- a/frontend/forms.js
+++ b/frontend/forms.js
@@ -163,7 +163,8 @@ var forms = module.exports = {
         // returns missing...
         var self = this,
             missing = {},
-            errors = e.responseJSON;
+            errors = e.responseJSON,
+            field_errors;
         $.each(errors, function(k) {
             if (k === 'non_field_errors') {
                 for (var i = 0; i < this.length; i++) {
@@ -176,11 +177,12 @@ var forms = module.exports = {
                 } else {
                     missing[k] = this[0];
                 }
+                field_errors = true;
             }
         })
         if (e.status >= 500) {
             $('.error-submission').text(i18n.t('Global.FormSubmissionError'));
-        } else if (e.status === 400) {
+        } else if (e.status === 400 && field_errors) {
             messages.add(i18n.t('Global.FormValidationError'));
         }
         return missing;

--- a/frontend/messages.js
+++ b/frontend/messages.js
@@ -2,13 +2,27 @@ var $ = require('jquery'),
     i18n = require('i18next-client'),
     template = require("./templates/message.hbs");
 
+var $app = $('#application');
+var $msg = $('#messages');
+var $doc = $(document);
+
 module.exports = {
     clear: function () {
-        $('#messages').html('');
+        var app_margin_top = $app.css('margin-top');
+        $app.css({
+            'margin-top': (app_margin_top - $msg.outerHeight()) + 'px'
+        })
+        $doc.scrollTop($doc.scrollTop() - $msg.outerHeight());
+        $msg.html('');
     },
     add: function (s) {
+        var app_margin_top = $('#application').css('margin-top');
         /* Add string 's' to the messages in the message area */
-        $('#messages').append(template({message: s}));
+        $msg.append(template({message: s}));
+        $app.css({
+            'margin-top': ($msg.outerHeight() + app_margin_top) 'px'
+        });
+        $doc.scrollTop($doc.scrollTop() + $msg.outerHeight());
     },
     error: function (e) {
         /* Given the argument to a promise error function, report

--- a/frontend/messages.js
+++ b/frontend/messages.js
@@ -11,7 +11,7 @@ module.exports = {
         var app_margin_top = $app.css('margin-top');
         $app.css({
             'margin-top': (app_margin_top - $msg.outerHeight()) + 'px'
-        })
+        });
         $doc.scrollTop($doc.scrollTop() - $msg.outerHeight());
         $msg.html('');
     },
@@ -20,7 +20,7 @@ module.exports = {
         /* Add string 's' to the messages in the message area */
         $msg.append(template({message: s}));
         $app.css({
-            'margin-top': ($msg.outerHeight() + app_margin_top) 'px'
+            'margin-top': ($msg.outerHeight() + app_margin_top) + 'px'
         });
         $doc.scrollTop($doc.scrollTop() + $msg.outerHeight());
     },

--- a/frontend/messages.js
+++ b/frontend/messages.js
@@ -2,12 +2,11 @@ var $ = require('jquery'),
     i18n = require('i18next-client'),
     template = require("./templates/message.hbs");
 
-var $app = $('#application');
-var $msg = $('#messages');
-var $doc = $(document);
-
 module.exports = {
     clear: function () {
+        var $app = $('#application');
+        var $msg = $('#messages');
+        var $doc = $(document);
         var app_margin_top = $app.css('margin-top');
         $app.css({
             'margin-top': (app_margin_top - $msg.outerHeight()) + 'px'
@@ -16,7 +15,10 @@ module.exports = {
         $msg.html('');
     },
     add: function (s) {
-        var app_margin_top = $('#application').css('margin-top');
+        var $app = $('#application');
+        var $msg = $('#messages');
+        var $doc = $(document);
+        var app_margin_top = $app.css('margin-top');
         /* Add string 's' to the messages in the message area */
         $msg.append(template({message: s}));
         $app.css({

--- a/frontend/styles/site.less
+++ b/frontend/styles/site.less
@@ -84,14 +84,12 @@ html,body {
         display: none;
     }
     width: 100%;
-    height: 58px;
+    position: fixed;
+    top: 0; left: 0;
+    z-index: 101;
     .message {
         padding: 20px 30px 20px;
-        position: fixed;
-        top: 0;
-        width: 100%;
-        z-index: 101;
-        margin-top: 0;
+        margin: 0;
         @media (min-width: 640px) {
             padding: 20px 30px;
         }


### PR DESCRIPTION
Right now, the #messages element is indeed being filled out with all relevant error messages. But because they're piled on top of one another, only the most recently added is visible.

This adjusts the style of #messages to allow all messages to be displayed, one on top of another (in the second dimension, not the third).

It also adds code to ensure that the page's margins are set to make the messages visible when they're displayed and to tuck content back in place after they're hidden.