### PR TITLE
SC-35 - integrate djangocms-googlemap -- adds Google Map plugin to CMS

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -98,3 +98,4 @@ git+git://github.com/caktus/aldryn-newsblog.git@1.0.9-323#egg=aldryn-newsblog
   pytz
   # six
   backport-collections==0.1
+djangocms-googlemap==0.4.0

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -262,6 +262,7 @@ INSTALLED_APPS = (
     'sortedm2m',
     'aldryn_faq',
     'taggit',
+    'djangocms_googlemap',
     # End Django CMS
     # Load after easy_thumbnails so that its thumbnail template tag (unused
     # in this project) is hidden.


### PR DESCRIPTION
djangocms-googlemap had a new release yesterday which removes the need for Django>=1.7 users to mess with ``MIGRATION_MODULES`` :)