### PR TITLE
Fixing footer bugs

### DIFF
--- a/service_info/static/js/src/component/footer.js
+++ b/service_info/static/js/src/component/footer.js
@@ -21,9 +21,11 @@ function init () {
 }
 
 function resize ($page, $footer) {
-  $page.css({
-    'padding-bottom': $footer.outerHeight() + 'px'
-  });
+  if ($(document).width() > 640) {
+    $page.css({
+      'padding-bottom': $footer.outerHeight() + 'px'
+    });
+  }
 }
 
 module.exports = init;

--- a/service_info/static/less/includes/footer.less
+++ b/service_info/static/less/includes/footer.less
@@ -7,7 +7,6 @@
 #footer {
   max-height: initial;
   height: auto;
-  margin: 0;
   position: absolute;
 
   .row {
@@ -17,7 +16,9 @@
     .align-items(baseline);
 
     .cms_placeholder {
-      width: auto;
+      width: 100%;
+      .flex(0, 1, auto);
+      display: none;
       /*
         This fixes a weird display glitch.
 

--- a/service_info/static/less/includes/footer.less
+++ b/service_info/static/less/includes/footer.less
@@ -8,7 +8,7 @@
   max-height: initial;
   height: auto;
   margin: 0;
-  position:relative;
+  position: absolute;
 
   .row {
     .flex-layout();

--- a/service_info/static/less/includes/footer.less
+++ b/service_info/static/less/includes/footer.less
@@ -1,8 +1,13 @@
 @import "./mixins.less";
 
+#page-container {
+  padding-bottom: 0;
+}
+
 #footer {
   max-height: initial;
   height: auto;
+  margin: 0;
   position:relative;
 
   .row {
@@ -12,7 +17,7 @@
     .align-items(baseline);
 
     .cms_placeholder {
-      width: 100%;
+      width: auto;
       /*
         This fixes a weird display glitch.
 

--- a/service_info/static/less/includes/header.less
+++ b/service_info/static/less/includes/header.less
@@ -18,7 +18,6 @@
         height: 160px;
         overflow: visible;
     }
-    @media (min-width: 1000px) {}
 }
 
 #cms-header .brand {

--- a/service_info/static/less/includes/header.less
+++ b/service_info/static/less/includes/header.less
@@ -18,8 +18,7 @@
         height: 160px;
         overflow: visible;
     }
-    @media (min-width: 1000px) {
-    }
+    @media (min-width: 1000px) {}
 }
 
 #cms-header .brand {
@@ -27,6 +26,7 @@
         background: white;
         padding: .25em .25em 0.1em;
         text-align: center;
+        height: 100%;
     }
 }
 


### PR DESCRIPTION
Issues resolved:

* Bottom padding on page element was being added inappropriately. This limits the JS padding-bottom adjustment to taking place when beneath the mobile breakpoint.
* `width:100%` was set unnecessarily on a CMS editor placeholder element. This removes that.
* While we're at it, this fixes the height property of the logo in the header on desktop size to remove an ugly line on the bottom.