### PR TITLE
Removing author metadata from the blog detail page

### DIFF
--- a/service_info/templates/aldryn_newsblog/includes/article.html
+++ b/service_info/templates/aldryn_newsblog/includes/article.html
@@ -44,8 +44,6 @@
             </div>
         {% endif %}
 
-        {% include "aldryn_newsblog/includes/author.html" with author=article.author %}
-
         {% if article.tags and detail_view %}
             <p class="tags">
                 {% if article.tags|length > 0 %} Tags:{% endif %}


### PR DESCRIPTION
Omar requested that the author metadata be removed from the blog posts [here](https://basecamp.com/1849796/projects/7911475/messages/51599627#comment_361542390). This does that.