### PR TITLE
Newsblog styles

### DIFF
--- a/service_info/static/less/base.less
+++ b/service_info/static/less/base.less
@@ -17,6 +17,9 @@
 #content {
     background-color: white;
     padding: 30px;
+    max-width: 960px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 ul {

--- a/service_info/static/less/content-types/aldryn-shared/index.less
+++ b/service_info/static/less/content-types/aldryn-shared/index.less
@@ -1,6 +1,10 @@
 @import "../../includes/mixins.less";
 @import "./pagination.less";
 
+*:not(.aldryn) > .aldryn {
+  font-size: 115%;
+}
+
 .aldryn {
   padding: 0 0 20px 0;
 

--- a/service_info/static/less/content-types/blog/pages/base.less
+++ b/service_info/static/less/content-types/blog/pages/base.less
@@ -8,14 +8,6 @@
 .aldryn-newsblog {
   padding: 0 0 20px 0;
 
-  // &:first-child {
-  //   margin-top: -30px;
-  // }
-
-  // > h2 {
-  //   padding: 0 0 1em 0;
-  // }
-
   > h2,
   > .aldryn-newsblog-list > h2 {
   }


### PR DESCRIPTION
Minor adjustments to newsblog styles:

* Limiting content well width to 960px.
* Increasing font size on all Aldryn pages.