### PR TITLE
Column layout

### DIFF
--- a/service_info/static/less/base.less
+++ b/service_info/static/less/base.less
@@ -31,4 +31,20 @@ ul.list-unstyled {
 
 .clearfix {
   overflow: hidden;
+
+  @media (max-width: 640px) {
+    /*
+      Column layouts are entirely useless on mobile devices. This disables
+      the column layout on mobile width, replacing it with a simple wrapped
+      flex row with automatically sized elements.
+    */
+    .flex-layout();
+    .flex-direction(row);
+    .flex-wrap(wrap);
+    > * {
+      .flex(0, 1, auto);
+      float: none !important;
+      width: auto !important;
+    }
+  }
 }

--- a/service_info/static/less/base.less
+++ b/service_info/static/less/base.less
@@ -28,3 +28,7 @@ ul.list-unstyled {
   list-style: none;
   padding-left: 0;
  }
+
+.clearfix {
+  overflow: hidden;
+}


### PR DESCRIPTION
These style modifications implement the column layout.

The Aldryn column system uses a float-based layout. This requires that a "clearfix" style be set on the container that holds the columns. The simplest implementation of this just sets `overflow: hidden` on the container. That is what has been used here.

Columns are inappropriate on mobile device widths. These new styles also disable the column layout on small devices.