### PR TITLE
SC-64: Upgrade django-cms from 3.1.3 to 3.1.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ xlrd==0.9.3
 sorl-thumbnail==12.3
 
 # CMS-related
-django-cms==3.1.3
+django-cms==3.1.4
   djangocms-admin-style==0.2.3
   django-classy-tags==0.6.2
   django-treebeard==3.0
@@ -52,7 +52,7 @@ git+git://github.com/caktus/aldryn-faq.git@1.0.8-146#egg=aldryn-faq
   aldryn-boilerplates==0.7.3
     YURL==0.13
     # django-appconf
-  aldryn-reversion==1.0.1
+  aldryn-reversion==1.0.3
     # django-reversion
   aldryn-search==0.2.10
     lxml==3.5.0
@@ -77,7 +77,7 @@ git+git://github.com/caktus/aldryn-faq.git@1.0.8-146#egg=aldryn-faq
   django-parler==1.5.1
   # django-reversion
   django-sortedm2m==1.0.2
-  django-taggit==0.17.3
+  django-taggit==0.17.6
 # Has missing migration: aldryn-newsblog==1.0.9
 git+git://github.com/caktus/aldryn-newsblog.git@1.0.9-323-ImproperlyConfigured#egg=aldryn-newsblog
   python-dateutil==2.4.2
@@ -87,7 +87,7 @@ git+git://github.com/caktus/aldryn-newsblog.git@1.0.9-323-ImproperlyConfigured#e
     # django-parler
     # django-treebeard
   # aldryn-common
-  aldryn-people==1.1.2
+  aldryn-people==1.1.3
     phonenumbers==7.1.1
     django-phonenumber-field==0.7.2
     # many others already listed


### PR DESCRIPTION
aldryn-reversion, aldryn-people, and django-taggit were also upgraded.

Tested successfully using a copy of production database from yesterday with additional testing of FAQ and NewsBlog.