### PR TITLE
SC-37 - new level of caktus/django-admin-sortable2 with...

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -73,7 +73,7 @@ git+git://github.com/caktus/aldryn-faq.git@1.0.8-146#egg=aldryn-faq
   django-admin-sortable==2.0.5
   # Has bug that breaks rich text editing of questions: django-admin-sortable2==0.6.0
   # Fails to deploy due to Unicode issue: git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50#egg=django-admin-sortable2
-  git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50-unicode#egg=django-admin-sortable2
+  git+git://github.com/caktus/django-admin-sortable2.git@0.6.0-50-unicode2#egg=django-admin-sortable2
   django-parler==1.5.1
   # django-reversion
   django-sortedm2m==1.0.2


### PR DESCRIPTION
...better fix for Unicode README

Please see https://github.com/caktus/django-admin-sortable2/commit/ddd86efaf3dca4761af8dc0ec66f7aca543902e1, which this picks up.

It should work fine (tested locally with LANG=) but I'd like to test it on a real deploy before I submit a pull request to django-admin-sortable2.

I found another setuptools package that used codecs.open as the fix for a similar issue, but io.open seems sufficient and io.open === Py3K open.
