### PR TITLE
Menu stopgap measures

### DIFF
--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -4,6 +4,8 @@
 @mobile-menu-height: 64px;
 
 #cms-nav {
+  overflow: hidden;
+
   padding-left: 2rem;
 
   @media (max-width: 992px) {
@@ -67,6 +69,10 @@
       height: @mobile-menu-height;
       line-height: @mobile-menu-height;
     }
+  }
+
+  #language-picker-trigger {
+    .flex(0, 0, auto);
   }
 
   .amber {

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -4,7 +4,6 @@
 @mobile-menu-height: 64px;
 
 #cms-nav {
-  overflow: hidden;
 
   padding-left: 2rem;
 
@@ -32,7 +31,7 @@
     */
     .brand-logo {
       position: relative;
-      .flex(0, 1, auto);
+      .flex(0, 0, auto);
 
       @media (max-width: 992px) {
         left: auto;
@@ -46,6 +45,8 @@
       .flex-direction(row);
       .flex-wrap(wrap); /* simulates truncation of items */
       .justify-content(flex-end);
+
+      overflow: hidden;
     }
 
     #cms-search {

--- a/service_info/templates/cms/includes/menu.html
+++ b/service_info/templates/cms/includes/menu.html
@@ -31,8 +31,10 @@
       {% endif %}
     </li>
   {% endfor %}
+</ul>
 
-  <li id="language-picker-trigger">
+<ul class="hide-on-med-and-down" id="language-picker-trigger">
+  <li>
     <a class="modal-trigger" href="#language-picker">Choose Language</a>
   </li>
 </ul>


### PR DESCRIPTION
Hides overflow content from the nav-menu. No more ghostly nav items floating around beneath the nav.

Relocates the language picker to its own `ul` outside the nav `ul` (an easy way to ensure it has the same appearance and behavior). This `ul` is not allowed to resize or wrap. Thus the items in the real nav `ul` will be squeezed out of their row while the language picker remains stoically in place.