### PR TITLE
dir property support

### DIFF
--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -45,3 +45,11 @@ img {
 .input-field .prefix {
   left: 0.5rem;
 }
+
+*[dir="RTL"] {
+  text-align: right/* rtl:right */;
+}
+
+*[dir="LTR"] {
+  text-align: left/* rtl:left */;
+}


### PR DESCRIPTION
Adding a Less rule to set `text-align` appropriately on elements with a `dir` property.

The rule includes directives for *rtlcss* that ensure that the rule is not flip-flopped when the page is in RTL mode.