### PR TITLE
SC-36  add aldryn-video

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -100,3 +100,6 @@ git+git://github.com/caktus/aldryn-newsblog.git@1.0.9-323-ImproperlyConfigured#e
   backport-collections==0.1
 djangocms-googlemap==0.4.0
 djangocms-column==1.6.0
+git+git://github.com/aldryn/aldryn-video.git@0.5.1#egg=aldryn-video
+  jsonfield==1.0.3
+  micawber==0.3.3

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -265,6 +265,7 @@ INSTALLED_APPS = (
     'taggit',
     'djangocms_googlemap',
     'djangocms_column',
+    'aldryn_video',
     # End Django CMS
     # Load after easy_thumbnails so that its thumbnail template tag (unused
     # in this project) is hidden.


### PR DESCRIPTION
This is not hosted on pypi, hence the installation from github.

I noticed some Python 2-isms in some of the code related to iframes, but I haven't been able to reproduce the problem; it isn't normally used.  If time allows I'll submit a pull request to the project and
not worry about integrating a fix into ServiceInfo at this time.

Notable advantages of aldryn-video over djangocms-video:

* working Vimeo support
* better widget for YouTube videos

I don't see any obvious need to mess with the included templates.

User instructions:
aldryn-video is named Generic/Video in the CMS list of available plug-ins.  Select that instead of Filer/Video.   (Filer/Video is just for uploaded videos, whereas aldryn-video is for YouTube/Vimeo-hosted videos.)

![image](https://cloud.githubusercontent.com/assets/1207350/11875672/d0552318-a4b3-11e5-8e52-d106e43b1764.png)
