### PR TITLE
SC-90: CMS lives on / (instead of front-end app)

### DIFF
--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -456,7 +456,7 @@ THUMBNAIL_HIGH_RESOLUTION = True
 TEXT_SAVE_IMAGE_FUNCTION = 'cmsplugin_filer_image.integrations.ckeditor.create_image_plugin'
 
 CMS_APP_NAME = 'cms'
-CMS_TOP_REL = r'cms/'
+CMS_TOP_REL = r''
 CMS_TOP = r'/' + CMS_TOP_REL
 DISQUS_SHORTNAME = 'trawicktestsites'  # allowed only on localhost
 ALDRYN_BOILERPLATE_NAME = 'bootstrap3'

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -456,7 +456,6 @@ THUMBNAIL_HIGH_RESOLUTION = True
 TEXT_SAVE_IMAGE_FUNCTION = 'cmsplugin_filer_image.integrations.ckeditor.create_image_plugin'
 
 CMS_APP_NAME = 'cms'
-CMS_TOP_REL = r''
-CMS_TOP = r'/' + CMS_TOP_REL
+CMS_TOP = r'/'
 DISQUS_SHORTNAME = 'trawicktestsites'  # allowed only on localhost
 ALDRYN_BOILERPLATE_NAME = 'bootstrap3'

--- a/service_info/templates/cms/includes/menu.html
+++ b/service_info/templates/cms/includes/menu.html
@@ -33,6 +33,8 @@
     <a class="modal-trigger" href="#language-picker">Choose Language</a>
   </li>
 
+  {% comment %}
+  Don't enable until CMS search actually works.
   <li class="no-padding">
     <form>
       <div class="input-field">
@@ -42,6 +44,7 @@
       </div>
     </form>
   </li>
+  {% endcomment %}
 
   {% if user.is_authenticated %}
     <li>

--- a/service_info/urls.py
+++ b/service_info/urls.py
@@ -6,7 +6,6 @@ from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.views.generic import RedirectView
 
 import api.urls
 from services.views import export_view, health_view, logout_view
@@ -39,11 +38,6 @@ urlpatterns = [
   + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:
-    urlpatterns += [
-        # Redirect / to /index.html if running locally.
-        url(r'^$', RedirectView.as_view(url=settings.STATIC_URL + 'index.html'),
-            name='index-html-redirect'),
-    ]
     import debug_toolbar
     urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),

--- a/service_info/urls.py
+++ b/service_info/urls.py
@@ -48,5 +48,5 @@ urlpatterns += i18n_patterns(
     # Django admin
     url(r'^admin/', include(admin.site.urls)),
     # Django CMS
-    url(r'^' + settings.CMS_TOP_REL, include('cms.urls', app_name=settings.CMS_APP_NAME)),
+    url(r'^', include('cms.urls', app_name=settings.CMS_APP_NAME)),
 )


### PR DESCRIPTION
* This needs a change to the nginx config to be effective on staging and production.  That will be a separate pull request for the other repo.
* I briefly considered changing the nginx config to redirect / to /cms/ but decided that wasn't likely what the customer expected or any sort of permanent solution.
* Interesting test db available upon request
* You may need to clear site history before you'll see your browser load the CMS for /