### PR TITLE
Keeping nav menus with active children open

### DIFF
--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -52,4 +52,19 @@ jQuery(function ($) {
   if (!isNaN(getInternetExplorerVersion())) {
     $('body').addClass('InternetExplorer');
   }
+
+  /*
+    Ensure that submenus with active children are open on page load.
+    Easiest way to do this: trigger the 'click' behavior on the containing
+    collapsible elements.
+  */
+  $('#nav .collapsible-body, #mobile-menu .collapsible-body')
+    .find('li.active')
+    .parents('#nav li')
+    .children('.collapsible-header')
+    .each(function () {
+      $(this).trigger('click');
+    })
+    .children('.collapsible-body')
+  ;
 });

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -65,6 +65,5 @@ jQuery(function ($) {
     .each(function () {
       $(this).trigger('click');
     })
-    .children('.collapsible-body')
   ;
 });

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -1,6 +1,6 @@
 {% load menu_tags i18n %}
 
-<ul class="collapsible collapsible-accordion">
+<ul class="collapsible" data-collapsible="expandable">
   <li class="">
     <a class="collapsible-header waves-effect">
       <div class="collapsible-header-wrap">


### PR DESCRIPTION
The easiest way to ensure that collapsible navigation menus with active children remain open is to trigger their opening behavior after the page loads by triggering a `click` event on the collapsible menu headers.

Why not just set the `active` class on those headers prior to the initialization of the collapsible menus? As it turns out, this looks exactly the same as this does—that is, there is a brief moment where the menus are not visibly expanded—so the improvement doesn't seem significant. This would also require wedging a `script` block between the jQuery include and the include for Materialize's JS, which doesn't seem good either.