### PR TITLE
Footer alignment

### DIFF
--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -35,11 +35,74 @@ main, footer {
 .multicolumn8,
 .multicolumn9,
 .multicolumn10 {
-  .column {
-    float: left !important;
+  .flex-layout();
+  .flex-wrap(wrap);
+  .flex-direction(row);
+  .column, .cms_plugin {
+    float: none !important;
+    width: auto !important;
     min-width: 200px;
-    padding-right: 10px;
-    margin-bottom: 1em;
+  }
+}
+
+.multicolumn0,
+.multicolumn1 {
+  .column, .cms_plugin {
+    .flex(1, 1, 100%);
+  }
+}
+
+.multicolumn2 {
+  .column, .cms_plugin {
+    .flex(1, 1, 50%);
+  }
+}
+
+.multicolumn3 {
+  .column, .cms_plugin {
+    .flex(1, 1, 33.333333%);
+  }
+}
+
+.multicolumn4 {
+  .column, .cms_plugin {
+    .flex(1, 1, 25%);
+  }
+}
+
+.multicolumn5 {
+  .column, .cms_plugin {
+    .flex(1, 1, 20%);
+  }
+}
+
+.multicolumn6 {
+  .column, .cms_plugin {
+    .flex(1, 1, 16.6666667%);
+  }
+}
+
+.multicolumn7 {
+  .column, .cms_plugin {
+    .flex(1, 1, 14.285714%);
+  }
+}
+
+.multicolumn8 {
+  .column, .cms_plugin {
+    .flex(1, 1, 12.5%);
+  }
+}
+
+.multicolumn9 {
+  .column, .cms_plugin {
+    .flex(1, 1, 11.1111111%);
+  }
+}
+
+.multicolumn10 {
+  .column, .cms_plugin {
+    .flex(1, 1, 10%);
   }
 }
 

--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -37,6 +37,9 @@ main, footer {
 .multicolumn10 {
   .column {
     float: left !important;
+    min-width: 200px;
+    padding-right: 10px;
+    margin-bottom: 1em;
   }
 }
 

--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -35,7 +35,7 @@ main, footer {
 .multicolumn8,
 .multicolumn9,
 .multicolumn10 {
-  .column, .cms_plugin {
+  .column {
     float: left !important;
     min-width: 200px;
     padding-right: 0.5rem;

--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -35,74 +35,11 @@ main, footer {
 .multicolumn8,
 .multicolumn9,
 .multicolumn10 {
-  .flex-layout();
-  .flex-wrap(wrap);
-  .flex-direction(row);
   .column, .cms_plugin {
-    float: none !important;
-    width: auto !important;
+    float: left !important;
     min-width: 200px;
-  }
-}
-
-.multicolumn0,
-.multicolumn1 {
-  .column, .cms_plugin {
-    .flex(1, 1, 100%);
-  }
-}
-
-.multicolumn2 {
-  .column, .cms_plugin {
-    .flex(1, 1, 50%);
-  }
-}
-
-.multicolumn3 {
-  .column, .cms_plugin {
-    .flex(1, 1, 33.333333%);
-  }
-}
-
-.multicolumn4 {
-  .column, .cms_plugin {
-    .flex(1, 1, 25%);
-  }
-}
-
-.multicolumn5 {
-  .column, .cms_plugin {
-    .flex(1, 1, 20%);
-  }
-}
-
-.multicolumn6 {
-  .column, .cms_plugin {
-    .flex(1, 1, 16.6666667%);
-  }
-}
-
-.multicolumn7 {
-  .column, .cms_plugin {
-    .flex(1, 1, 14.285714%);
-  }
-}
-
-.multicolumn8 {
-  .column, .cms_plugin {
-    .flex(1, 1, 12.5%);
-  }
-}
-
-.multicolumn9 {
-  .column, .cms_plugin {
-    .flex(1, 1, 11.1111111%);
-  }
-}
-
-.multicolumn10 {
-  .column, .cms_plugin {
-    .flex(1, 1, 10%);
+    padding-right: 0.5rem;
+    box-sizing: border-box;
   }
 }
 

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -62,20 +62,7 @@
     <footer id="cms-footer" class="{% block footer-class %}page-footer grey darken-3{% endblock footer-class %}">
       {% block footer %}
         <div class="container white-text">
-          <div class="row">
-            <div class="col s12 m9">
-              {% static_placeholder "footer_content" %}
-            </div>
-            <div class="col s12 m3">
-              <h6 class="grey-text">{% trans "Search for Services Nearby" %}</h6>
-              <p>
-                <a href="/app/index.html" class="waves-effect waves-light btn-large">
-                  Services
-                  <i class="material-icons right">search</i>
-                </a>
-              </p>
-            </div>
-          </div>
+          {% static_placeholder "footer_content" %}
         </div>
         <div class="footer-copyright grey-text">
           <div class="container">

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -62,7 +62,22 @@
     <footer id="cms-footer" class="{% block footer-class %}page-footer grey darken-3{% endblock footer-class %}">
       {% block footer %}
         <div class="container white-text">
-          {% static_placeholder "footer_content" %}
+          <div class="row">
+            <div class="col">
+              {% static_placeholder "footer_content" %}  
+            </div>
+          </div>
+          <div class="row">
+            <div class="col">
+              <h6 class="grey-text">Search for Services Nearby</h6>
+              <p>
+                <a href="/app/index.html" class="waves-effect waves-light btn-large">
+                  Services
+                  <i class="material-icons right">search</i>
+                </a>
+              </p>
+            </div>
+          </div>
         </div>
         <div class="footer-copyright grey-text">
           <div class="container">

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -64,15 +64,15 @@
         <div class="container white-text">
           <div class="row">
             <div class="col">
-              {% static_placeholder "footer_content" %}  
+              {% static_placeholder "footer_content" %}
             </div>
           </div>
           <div class="row">
             <div class="col">
-              <h6 class="grey-text">Search for Services Nearby</h6>
+              <h6 class="grey-text">{% trans "Search for Services Nearby" %}</h6>
               <p>
                 <a href="/app/index.html" class="waves-effect waves-light btn-large">
-                  Services
+                  {% trans "Services" %}
                   <i class="material-icons right">search</i>
                 </a>
               </p>


### PR DESCRIPTION
Tries to address issues with footer alignment.

* Adds minimum width to all multicolumn layout columns, forcing them to wrap when the container is too narrow. It just looks *bad* when columns are squeezed into too narrow a space; the django-cms multicolumn plugin is just plain not responsive. A total rework of the multicolumn layout's CSS is possible (you could do it with flexbox, for instance, and set up specific breakpoints for each number of columns), but setting a minimum width is a quick-fix alternative.
* Moves the "Search for Services Nearby" button out of the same row as the rest of the footer content. Omar approved our suggestion to remove that button from the flow of footer content and place it below. This prevents some awkward wrapping issues.