### PR TITLE
Boxing the homepage content well

### DIFF
--- a/service_info/static/less/content-types/homepage.less
+++ b/service_info/static/less/content-types/homepage.less
@@ -57,7 +57,12 @@ section.hero {
 section.main-content {
   padding: 0 20px;
 
-  .main-col {}
+  .main-col {
+    .main-container {
+      max-width: 820px;
+      margin: auto;
+    }
+  }
 
   .secondary-col {
     padding: 1.5em 1em;

--- a/service_info/templates/cms/content-types/homepage.html
+++ b/service_info/templates/cms/content-types/homepage.html
@@ -20,7 +20,9 @@
 {% block secondary-column-class %}secondary-col{% endblock secondary-column-class %}
 
 {% block content %}
-  {% static_placeholder "content" %}
+  <div class="main-container">
+    {% static_placeholder "content" %}
+  </div>
 {% endblock content %}
 
 {% block sidebar-content %}


### PR DESCRIPTION
At Omar's request, the width of the main content area on the homepage should be limited so that it doesn't take up a huge area on wide screens.

This adds a container and some CSS to restrict the width.