### PR TITLE
New styles for sub-menus

### DIFF
--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -59,11 +59,8 @@ jQuery(function ($) {
     collapsible elements.
   */
   $('#nav .collapsible-body, #mobile-menu .collapsible-body')
-    .find('li.active')
+    .find('li.page-active')
     .parents('#nav li, #mobile-menu li')
-    .each(function () {
-      $(this).addClass('active');
-    })
     .children('.collapsible-header')
     .each(function () {
       $(this).trigger('click');

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -60,7 +60,10 @@ jQuery(function ($) {
   */
   $('#nav .collapsible-body, #mobile-menu .collapsible-body')
     .find('li.active')
-    .parents('#nav li')
+    .parents('#nav li, #mobile-menu li')
+    .each(function () {
+      $(this).addClass('active');
+    })
     .children('.collapsible-header')
     .each(function () {
       $(this).trigger('click');

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -6,6 +6,10 @@
 @active-item-hover: #e57373;
 
 .side-nav, .side-nav.fixed {
+  > li > .collapsible > .page-active,
+  > li.page-active {
+    background-color: #ffca28;
+  }
   li {
     &:not(.logo) {
       .flex-layout();
@@ -98,7 +102,7 @@
       }
     }
 
-    &.active {
+    &.active, &:hover {
        background-color: #ffca28;
     }
 

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -104,7 +104,7 @@
     }
 
     &.active, &:hover {
-       background-color: #ffca28;
+      background-color: #ffca28;
     }
 
     &.page-active {

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -42,6 +42,23 @@
         }
       }
     }
+
+    .overlay {
+      height: 48px;
+      position: absolute;
+      z-index: 2;
+      width: 190px;
+      .flex-layout();
+      .align-items(center);
+      a {
+        .flex-layout();
+        .align-items(center);
+        padding-left: 30px;
+        width: 100%;
+        display: inline-flex;
+      }
+    }
+
     a {
       min-height: @side-nav-height;
       height: auto;
@@ -51,14 +68,27 @@
       .align-items(center);
 
       &.collapsible-header {
+        &:not(.active) + .collapsible-body .overlay {
+          display: none;
+        }
+
         .collapsible-header-wrap {
           .flex-layout();
           .flex-direction(row);
           .align-items(center);
           .justify-content(space-between);
           .flex(0, 1, 100%);
+
+          i {
+            .flex-layout();
+            .align-items(center);
+            .justify-content(center);
+            height: 48px;
+            width: 48px;
+            background-color: rgba(255,255,255,0.75);
+          }
         }
-        padding: 0 30px;
+        padding: 0 0 0 30px;
         width: 100%;
         box-sizing: border-box;
         margin: 0;
@@ -100,6 +130,11 @@
         color: black !important;
         margin: 0 15px;
         &.collapsible-header {
+          margin: 0;
+        }
+      }
+      .overlay {
+        a {
           margin: 0;
         }
       }

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -50,6 +50,7 @@
     .overlay {
       height: 48px;
       position: absolute;
+      left: 0;
       z-index: 2;
       width: 190px;
       .flex-layout();

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -82,6 +82,8 @@
   }
 
   .collapsible-body {
+    border-left: 3px solid rgba(0,0,0,0.15)!important;
+    margin-left: 5px;
     background-color: #ffe082;
     .collapsible-body {
       background-color: #ffecb3;
@@ -91,8 +93,8 @@
     }
 
     li {
-      &.active {
-        background-color: #ffca28;
+      &.active, &:hover {
+        background-color: transparent;
       }
       a {
         color: black !important;

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -98,12 +98,17 @@
       }
     }
 
-    &.active {
-      background-color: #ffca28;
+    &.active, &:hover {
+      background-color: transparent;
     }
 
-    &:hover {
-      background-color: #ffca28;
+    &.page-active {
+      > ul > li > .overlay {
+        font-weight: 800;
+      }
+      > a {
+        font-weight: 800;
+      }
     }
 
     &.logo:hover {

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -98,8 +98,8 @@
       }
     }
 
-    &.active, &:hover {
-      background-color: transparent;
+    &.active {
+       background-color: #ffca28;
     }
 
     &.page-active {

--- a/service_info/templates/cms/includes/menu.html
+++ b/service_info/templates/cms/includes/menu.html
@@ -19,11 +19,11 @@
 
   {% for child in children %}
     {% if child.children %}
-      <li class="no-padding {% if child.selected %}active{% endif %}">
+      <li class="no-padding {% if child.selected %}page-active{% endif %}">
         {% show_menu from_level to_level extra_inactive extra_active "cms/includes/sub_menu.html" "" "" child %}
       </li>
     {% else %}
-      <li class="{% if child.selected %}active{% endif %}">
+      <li class="{% if child.selected %}page-active{% endif %}">
         <a href="{{ child.get_absolute_url }}">
           {% if child.iconnameextension.icon_name %}
             <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -1,26 +1,26 @@
 {% load menu_tags i18n %}
 
 <ul class="collapsible" data-collapsible="expandable">
-  <li class="">
+  <li class="{% if child.selected %}active{% endif %}">
+    {% if child.children %}
+      <div class="overlay">
+        <a href="{{ child.get_absolute_url }}" class="waves-effect">
+          {{ child.get_menu_title }}
+        </a>
+      </div>
+    {% endif %}
     <a class="collapsible-header waves-effect">
       <div class="collapsible-header-wrap">
-        {{ child.get_menu_title }}
         {% if child.children %}
+          &nbsp;
           <i class="material-icons right">arrow_drop_down</i>
+        {% else %}
+          {{ child.get_menu_title }}
         {% endif %}
       </div>
     </a>
     <div class="collapsible-body">
       <ul>
-        <li class="{% if child.selected %}active{% endif %}">
-          <a href="{{ child.get_absolute_url }}">
-            {% if child.iconnameextension.icon_name %}
-              <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>
-            {% endif %}
-
-            {{ child.get_menu_title }}
-          </a>
-        </li>
         {% for child in child.children %}
           {% if child.children %}
             <li class="no-padding">

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -1,7 +1,7 @@
 {% load menu_tags i18n %}
 
 <ul class="collapsible" data-collapsible="expandable">
-  <li class="">
+  <li class="{% if child.selected %}page-active{% endif %}">
     {% if child.children %}
       <div class="overlay">
         <a href="{{ child.get_absolute_url }}" class="waves-effect">

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -27,7 +27,7 @@
               {% show_menu from_level to_level extra_inactive extra_active "cms/includes/sub_menu.html" "" "" child %}
             </li>
           {% else %}
-            <li class=" {% if child.selected %}page-active{% endif %}">
+            <li class="{% if child.selected %}page-active{% endif %}">
               <a href="{{ child.get_absolute_url }}">
                 {% if child.iconnameextension.icon_name %}
                   <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -1,7 +1,7 @@
 {% load menu_tags i18n %}
 
 <ul class="collapsible" data-collapsible="expandable">
-  <li class="{% if child.selected %}active{% endif %}">
+  <li class="">
     {% if child.children %}
       <div class="overlay">
         <a href="{{ child.get_absolute_url }}" class="waves-effect">
@@ -23,11 +23,11 @@
       <ul>
         {% for child in child.children %}
           {% if child.children %}
-            <li class="no-padding">
+            <li class="no-padding {% if child.selected %}page-active{% endif %}">
               {% show_menu from_level to_level extra_inactive extra_active "cms/includes/sub_menu.html" "" "" child %}
             </li>
           {% else %}
-            <li class="{% if child.selected %}active{% endif %}">
+            <li class=" {% if child.selected %}page-active{% endif %}">
               <a href="{{ child.get_absolute_url }}">
                 {% if child.iconnameextension.icon_name %}
                   <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>


### PR DESCRIPTION
Previously, the appearance of deeply embedded sub-menus lacked clarity. This is an attempt to address that problem.

Pages with children no longer appear in the menu twice (once for the drop-down activator, once in the body of the drop-down). Instead, they appear as normal menu items except for a right-aligned button that drops down the sub-menu.

Sub-menus are now slightly indented and have a small left border (sort of like the quotation level in an email thread).

Highlighting of active items, except on the top-most menu, no longer uses color. Instead only font weight is used.