### PR TITLE
SC-113: put logo on white background

### DIFF
--- a/service_info/static/less/base/header/brand.less
+++ b/service_info/static/less/base/header/brand.less
@@ -2,7 +2,8 @@
 
 .side-nav {
   .logo {
-    padding: 2rem;
+    padding: 2rem 3rem;
+    background-color: white !important;
     @media (max-width: 991px) {
       height: 128px;
       padding: 1rem;

--- a/service_info/static/less/base/header/mobile-nav.less
+++ b/service_info/static/less/base/header/mobile-nav.less
@@ -4,7 +4,7 @@
 
 #mobile-nav {
   height: @mobile-nav-height;
-  padding-left: 1rem;
+  padding-left: 0;
 
   a.button-collapse {
     height: @mobile-nav-height;
@@ -15,12 +15,17 @@
   }
 
   > .nav-wrapper > a.brand-logo {
+    background-color: white;
+    left: 0;
+    height: 72px;
+    width: 72px;
+    box-sizing: border-box;
     .flex-layout();
     .align-items(center);
+    .justify-content(center);
+    padding: 10px;
 
     height: 100%;
-
-    padding: 6px;
 
     > img {
       height: 100%;

--- a/service_info/static/less/base/header/mobile-nav.less
+++ b/service_info/static/less/base/header/mobile-nav.less
@@ -9,6 +9,7 @@
   a.button-collapse {
     height: @mobile-nav-height;
     line-height: @mobile-nav-height;
+    width: 56px;
     * {
       line-height: inherit;
     }

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -36,9 +36,9 @@
         {% endblock nav %}
         <nav id="mobile-nav" class="hide-on-large-only {% block nav-class %}nav-wrapper amber lighten-2{% endblock nav-class %}">
           <div class="nav-wrapper">
-            <a href="#" data-activates="mobile-menu" class="button-collapse"><i class="material-icons">menu</i></a>
+            <a href="#" data-activates="mobile-menu" class="button-collapse right"><i class="material-icons">menu</i></a>
 
-            <a href="{% url 'pages-root' %}" class="{% block brand-class %}brand-logo{% endblock brand-class %}">
+            <a href="{% url 'pages-root' %}" class="{% block brand-class %}brand-logo{% endblock brand-class %} left">
               <img src="{% static 'images/logo-large.png' %}">
             </a>
 


### PR DESCRIPTION
This attempts to implement Omar's instruction that the logo should be smaller and placed on a white background.

On the desktop version, this is straightforward.

On the mobile version, it requires some relocation of elements to not look silly. The logo has been moved to the left edge of the nav bar and the hamburger button to the right. (This has been checked on RTL.)