### PR TITLE
SC-117: image sliders

### DIFF
--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -47,6 +47,11 @@ jQuery(function ($) {
   }
 
   /*
+    Activate Materialize sliders.
+  */
+  $('.slider').slider({full_width: true});
+
+  /*
     Adjust for IE 11.
   */
   if (!isNaN(getInternetExplorerVersion())) {

--- a/service_info/static/less/base/index.less
+++ b/service_info/static/less/base/index.less
@@ -2,3 +2,4 @@
 @import "./header/index.less";
 @import "./footer/index.less";
 @import "./footer.less";
+@import "./materialize/index.less";

--- a/service_info/static/less/base/materialize/index.less
+++ b/service_info/static/less/base/materialize/index.less
@@ -1,0 +1,1 @@
+@import "./slider.less";

--- a/service_info/static/less/base/materialize/slider.less
+++ b/service_info/static/less/base/materialize/slider.less
@@ -1,0 +1,5 @@
+.slider {
+  h3, h5 {
+    text-shadow: 0 3px 3px black;
+  }
+}


### PR DESCRIPTION
With these small additions, it's possible to add a Materialize slider element to the page.

This must be done by editing the raw HTML of a content area. The steps look like this:

* Add image objects to the desired placeholder or plugin.
* Edit the HTML of the plugin you wish to add an image slider to.
* Add the HTML structured [described in the Materialize docs](http://materializecss.com/media.html#slider), using the URLs taken from the `<img>` elements created in the previous step (which should be visible in the HTML).
* Save(, publish,) and refresh. *The sliders will not work unless the script to initialize sliders has run, which happens when the page loads.*