### PR TITLE
Abstracting Materialize colors

### DIFF
--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -1,6 +1,7 @@
 @import "../includes/mixins.less";
+@import "../includes/variables.less";
 
-@highlight-color: #ffd54f;
+@highlight-color: @amber-lighten-2;
 
 * {
   text-align: left;

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -1,4 +1,5 @@
 @import "../../includes/mixins.less";
+@import "../../includes/variables.less";
 
 @side-nav-height: 48px;
 @search-item-height: 56px;
@@ -8,7 +9,7 @@
 .side-nav, .side-nav.fixed {
   > li > .collapsible > .page-active,
   > li.page-active {
-    background-color: #ffca28;
+    background-color: @amber-lighten-1;
   }
   li {
     position: relative;
@@ -110,7 +111,7 @@
     }
 
     &.active, &:hover {
-      background-color: #ffca28;
+      background-color: @amber-lighten-1;
     }
 
     &.page-active {
@@ -151,11 +152,11 @@
   .collapsible-body {
     border-left: 3px solid rgba(0,0,0,0.15)!important;
     margin-left: 5px;
-    background-color: #ffe082;
+    background-color: @amber-lighten-3;
     .collapsible-body {
-      background-color: #ffecb3;
+      background-color: @amber-lighten-4;
       .collapsible-body {
-        background-color: #fff8e1;
+        background-color: @amber-lighten-5;
       }
     }
 

--- a/service_info/static/less/includes/variables.less
+++ b/service_info/static/less/includes/variables.less
@@ -1,0 +1,17 @@
+/*
+  Variables for Materialize color palette names.
+*/
+@amber-lighten-5: #fff8e1;
+@amber-lighten-4: #ffecb3;
+@amber-lighten-3: #ffe082;
+@amber-lighten-2: #ffd54f;
+@amber-lighten-1: #ffca28;
+@amber: #ffc107;
+@amber-darken-1: #ffb300;
+@amber-darken-2: #ffa000;
+@amber-darken-3: #ff8f00;
+@amber-darken-4: #ff6f00;
+@amber-accent-1: #ffe57f;
+@amber-accent-2: #ffd740;
+@amber-accent-3: #ffc400;
+@amber-accent-4: #ffab00;


### PR DESCRIPTION
Colors from the [Materialize color palettes](http://materializecss.com/color.html) have been used in the raw in various places (especially the menus, where different tiers of menu items have different shades of "amber" in the background).

This assigns variable names to the colors derived from the palette's color names to make it easier to understand what's going on with those colors by clarifying their "meaning".