### PR TITLE
SC-38 Stop using fork of aldryn-faq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
 - psql service_info -c "CREATE EXTENSION postgis;" -U postgres
 - gulp build
 script:
-- python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
 - coverage run manage.py test
 - coverage report -m --fail-under 60
 - flake8 .

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,8 +45,7 @@ cmsplugin-iframe==0.1.3
 djangocms-text-ckeditor==2.7.0
 django-reversion==1.8.5
 aldryn-disqus==1.0.0
-# Has missing migration: aldryn-faq==1.0.8
-git+git://github.com/caktus/aldryn-faq.git@1.0.8-146#egg=aldryn-faq
+aldryn-faq==1.0.11
   aldryn-apphooks-config==0.2.6
     django-appdata==0.1.4
       South==1.0.2

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,4 +6,3 @@ flake8 .
 rm -f .coverage
 coverage run manage.py test --noinput --settings=service_info.settings.dev "$@"
 coverage report
-python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -7,7 +7,7 @@ from django.core import management
 
 EXPECTED_CHANGES = {
     'aldryn_faq': [
-        # Py3K-izing default=b'{}', which is interpreted with encoding UTF-8
+        # Py3K-izing default=b'{}', which is interpreted with encoding UTF-8:
         # migrations.AlterField(
         #     model_name='faqconfig',
         #     name='app_data',
@@ -17,31 +17,48 @@ EXPECTED_CHANGES = {
 }
 
 
+class MigrationCommandOutput(object):
+    """Parse output from makemigrations command, generating a series of
+      (module, changed_fields)"""
+
+    INITIAL = 'INITIAL'
+    READING = 'READING'  # reading changes for package
+
+    def __init__(self, input_file):
+        self.input = input_file
+
+    def read(self):
+        actual_changes = []
+        module = ''
+        state = self.INITIAL
+        while True:
+            l = self.input.readline()
+            if l in ('', 'No changes detected'):
+                break
+            if l.startswith('Migrations'):
+                if state != self.INITIAL:
+                    yield module, actual_changes
+                state = self.READING
+                module = re.match(r'^Migrations for \'(.+)\'', l).group(1)
+            elif re.search(r'^ +.*\.py:', l):
+                continue
+            else:
+                if state != self.READING:
+                    raise ValueError('State is <%s> instead of <R>' % state)
+                actual_changes.append(l.strip())
+        if state != self.INITIAL:
+            yield module, actual_changes
+
+
 class MissingMigrationTestCase(TestCase):
 
     def test(self):
-        state = 'I'  # 'I' == initial, 'R' == reading changes for module
-        actual_changes = []
-        module = ''
         actual_modules = []
         with io.StringIO() as f:
             management.call_command('makemigrations', dry_run=True, stdout=f, no_color=True)
             f.seek(0)
-            while True:
-                l = f.readline()
-                if l in ('', 'No changes detected'):
-                    break
-                if l.startswith('Migrations'):
-                    if state != 'I':
-                        self.assertEqual(EXPECTED_CHANGES[module], actual_changes)
-                    state = 'R'
-                    module = re.match(r'^Migrations for \'(.+)\'', l).group(1)
-                    actual_modules.append(module)
-                elif re.search(r'^ +.*\.py:', l):
-                    continue
-                else:
-                    self.assertTrue(state == 'R')
-                    actual_changes.append(l.strip())
-        if state != 'I':
-            self.assertEqual(EXPECTED_CHANGES[module], actual_changes)
+            migrations = MigrationCommandOutput(f)
+            for module, actual_changes in migrations.read():
+                actual_modules.append(module)
+                self.assertEqual(EXPECTED_CHANGES[module], actual_changes)
         self.assertEqual(sorted(EXPECTED_CHANGES.keys()), sorted(actual_modules))

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -1,0 +1,47 @@
+import io
+import re
+
+from django.test import TestCase
+from django.core import management
+
+
+EXPECTED_CHANGES = {
+    'aldryn_faq': [
+        # Py3K-izing default=b'{}', which is interpreted with encoding UTF-8
+        # migrations.AlterField(
+        #     model_name='faqconfig',
+        #     name='app_data',
+        #     field=app_data.fields.AppDataField(default=b'{}', editable=False),
+        '- Alter field app_data on faqconfig',
+    ],
+}
+
+
+class MissingMigrationTestCase(TestCase):
+
+    def test(self):
+        state = 'I'  # 'I' == initial, 'R' == reading changes for module
+        actual_changes = []
+        module = ''
+        actual_modules = []
+        with io.StringIO() as f:
+            management.call_command('makemigrations', dry_run=True, stdout=f, no_color=True)
+            f.seek(0)
+            while True:
+                l = f.readline()
+                if l in ('', 'No changes detected'):
+                    break
+                if l.startswith('Migrations'):
+                    if state != 'I':
+                        self.assertEqual(EXPECTED_CHANGES[module], actual_changes)
+                    state = 'R'
+                    module = re.match(r'^Migrations for \'(.+)\'', l).group(1)
+                    actual_modules.append(module)
+                elif re.search(r'^ +.*\.py:', l):
+                    continue
+                else:
+                    self.assertTrue(state == 'R')
+                    actual_changes.append(l.strip())
+        if state != 'I':
+            self.assertEqual(EXPECTED_CHANGES[module], actual_changes)
+        self.assertEqual(sorted(EXPECTED_CHANGES.keys()), sorted(actual_modules))

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -46,7 +46,9 @@ class MigrationCommandOutput(object):
                 continue
             else:
                 if state != self.READING:
-                    raise ValueError('State is <%s> instead of <R>' % state)
+                    raise ValueError('State is <%s> instead of <%s>' % (
+                        state, self.READING
+                    ))
                 actual_changes.append(l.strip())
         if state != self.INITIAL:
             yield module, actual_changes

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -11,7 +11,9 @@ EXPECTED_CHANGES = {
         # migrations.AlterField(
         #     model_name='faqconfig',
         #     name='app_data',
-        #     field=app_data.fields.AppDataField(default=b'{}', editable=False),
+        #     field=app_data.fields.AppDataField(default='{}', editable=False),
+        #     preserve_default=True,
+        # ),
         '- Alter field app_data on faqconfig',
     ],
 }

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -42,6 +42,7 @@ class MigrationCommandOutput(object):
                     yield module, actual_changes
                 state = self.READING
                 module = re.match(r'^Migrations for \'(.+)\'', l).group(1)
+                actual_changes = []
             elif re.search(r'^ +.*\.py:', l):
                 continue
             else:


### PR DESCRIPTION
We were using a fork of aldryn-faq that added a missing migration on top of aldryn-faq 1.0.8.  That migration is an unnecessary tweak Django generates when using Python 3.  (See the new testcase for the actual ``AlterField``.)

* Move up to aldryn-faq 1.0.11, the current version, from PyPI.
* Re-implement the check for missing migrations as a ``TestCase`` that knows how to filter out expected changes to fields.

**Important note for picking up this code** -- dev, staging, production:

* The DB migrations **must be rolled back** to ``aldryn_faq 0008`` before deploying or otherwise updating the virtualenv with these requirements, in order to undo the unnecessary migration in our fork; the subsequent deploy will apply a couple of other migrations added as of the aldryn-faq 1.0.11 release.

Production notes:

* Production has a FAQ config and a question but does not have a FAQ page enabled.  I tested successfully with the production DB + a FAQ page that displayed the question + an extra question or two.