### PR TITLE
SC-39 - Upgrading to unmodified aldryn-newsblog 1.0.12

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-06 14:55+0200\n"
+"POT-Creation-Date: 2016-01-13 17:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -365,6 +365,9 @@ msgid "Created by the IRC"
 msgstr ""
 
 msgid "Choose language"
+msgstr ""
+
+msgid "Choose Language"
 msgstr ""
 
 msgid "Logout"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-13 17:42+0200\n"
+"POT-Creation-Date: 2016-01-13 19:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -362,9 +362,6 @@ msgid "IRC Info Portal"
 msgstr ""
 
 msgid "Created by the IRC"
-msgstr ""
-
-msgid "Choose language"
 msgstr ""
 
 msgid "Choose Language"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -79,8 +79,7 @@ git+git://github.com/caktus/aldryn-faq.git@1.0.8-146#egg=aldryn-faq
   # django-reversion
   django-sortedm2m==1.0.2
   django-taggit==0.17.6
-# Has missing migration and other issues: aldryn-newsblog==1.0.9
-git+git://github.com/caktus/aldryn-newsblog.git@1.0.9-323-ImproperlyConfigured-334#egg=aldryn-newsblog
+aldryn-newsblog==1.0.12
   python-dateutil==2.4.2
   # aldryn-apphooks-config
   # aldry-boilerplates

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -16,6 +16,25 @@ EXPECTED_CHANGES = {
         # ),
         '- Alter field app_data on faqconfig',
     ],
+    'aldryn_newsblog': [
+        # newsblogconfig.app_data is same story as faqconfig.app_data above
+        # migrations.AlterField(
+        #     model_name='newsblogconfig',
+        #     name='app_data',
+        #     field=app_data.fields.AppDataField(default='{}', editable=False),
+        #     preserve_default=True,
+        # ),
+        '- Alter field app_data on newsblogconfig',
+        # Removing choices since choices has a different value since the last
+        # time (now: [], before: [(b'dummy', b'dummy')])
+        # migrations.AlterField(
+        #     model_name='newsblogconfig',
+        #     name='template_prefix',
+        #     field=models.CharField(blank=True, verbose_name='Prefix for template dirs', max_length=20, null=True),
+        #     preserve_default=True,
+        # ),
+        '- Alter field template_prefix on newsblogconfig',
+    ],
 }
 
 

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -30,7 +30,8 @@ EXPECTED_CHANGES = {
         # migrations.AlterField(
         #     model_name='newsblogconfig',
         #     name='template_prefix',
-        #     field=models.CharField(blank=True, verbose_name='Prefix for template dirs', max_length=20, null=True),
+        #     field=models.CharField(blank=True, verbose_name='Prefix for template dirs',
+        #         max_length=20, null=True),
         #     preserve_default=True,
         # ),
         '- Alter field template_prefix on newsblogconfig',


### PR DESCRIPTION
This pull request includes the changes in https://github.com/theirc/ServiceInfo/pull/149 for SC-38 Stop using fork of aldryn-faq.

SC-38:

We were using a fork of aldryn-faq that added a missing migration on top of aldryn-faq 1.0.8.  That migration is an unnecessary tweak Django generates when using Python 3.  (See the new testcase for the actual ``AlterField``.)

* Move up to aldryn-faq 1.0.11, the current version, from PyPI.
* Re-implement the check for missing migrations as a ``TestCase`` that knows how to filter out expected changes to fields.

SC-39:

(same story, except one of the changes is related to Python3 and the other is related to a change in the value of ``choices=`` for a field due to a setting.)

**Important note for picking up this code** -- dev, staging, production:

SC-38:
* The DB migrations **must be rolled back** to ``aldryn_faq 0008`` before deploying or otherwise updating the virtualenv with these requirements, in order to undo the unnecessary migration in our fork; the subsequent deploy will apply a couple of other migrations added as of the aldryn-faq 1.0.11 release.

SC-39:
* The DB migrations **must be rolled back** to ``aldryn_newsblog 0005`` before deploying or otherwise updating the virtualenv with these requirements, in order to undo the unnecessary migration in our fork; the subsequent deploy will apply a few other migrations added as of the aldryn-newsblog 1.0.12 release.

Production notes:

* Production has a FAQ config and a question but does not have a FAQ page enabled.  I tested successfully with the production DB + a FAQ page that displayed the question + an extra question or two.
* Production has a NewsBlog config and article and unpublished page.  The unpublished page won't work until a news plugin is enabled.