### PR TITLE
Limiting text highlighting to non-parent menu items

### DIFF
--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -55,7 +55,7 @@
       a {
         color: black;
       }
-      li:hover {
+      li:not(.parent):hover {
         a {
           color: white;
         }


### PR DESCRIPTION
This one-liner fixes the unfortunate bug that made it to staging by restricting the highlighting of text to non-parent menu list items.