### PR TITLE
Menu icon bugfixes

### DIFF
--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -75,18 +75,4 @@ jQuery(function ($) {
       $('#page-rating').submit();
     }, 1500);
   }
-
-  /*
-    Ensure that submenus with active children are open on page load.
-    Easiest way to do this: trigger the 'click' behavior on the containing
-    collapsible elements.
-  */
-  $('#nav .collapsible-body, #mobile-menu .collapsible-body')
-    .find('li.page-active')
-    .parents('#nav li, #mobile-menu li')
-    .children('.collapsible-header')
-    .each(function () {
-      $(this).trigger('click');
-    })
-  ;
 });

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -253,15 +253,19 @@
           .flex-layout();
           .flex-direction(row);
           .align-items(center);
-          .justify-content(space-between);
+          .justify-content(flex-start);
           .flex(0, 1, 100%);
           flex-basis: 100% !important;
 
+          > span {
+            .flex(1, 1, auto);
+          }
+
           i {
-            .flex(0, 0, 48px);
+            .flex(0, 0, 36px);
             .flex-layout();
             .align-items(center);
-            .justify-content(center);
+            .justify-content(flex-start);
             height: 48px;
             width: 48px;
           }

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -271,6 +271,10 @@
           }
         }
         padding: 0 0 0 30px;
+        &.has_icon {
+          // icon looks better slightly displaced to the left
+          padding: 0 0 0 25px;
+        }
         width: 100%;
         box-sizing: border-box;
         margin: 0;
@@ -326,6 +330,11 @@
           margin: 0;
         }
       }
+    }
+
+    > ul > li.has_icon > a {
+      // visual adjustment for icons on non-parent child list item
+      padding: 0 30px 0 25px;
     }
   }
 }

--- a/service_info/templates/cms/includes/menu.html
+++ b/service_info/templates/cms/includes/menu.html
@@ -29,7 +29,7 @@
             <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>
           {% endif %}
 
-          {{ child.get_menu_title }}
+          <span>{{ child.get_menu_title }}</span>
         </a>
       </li>
     {% endif %}

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -10,11 +10,15 @@
     {% endif %}
     <a class="collapsible-header waves-effect {% if child.ancestor %}active{% endif %}">
       <div class="collapsible-header-wrap">
+        {% if child.iconnameextension.icon_name %}
+          <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>
+        {% endif %}
+
         {% if child.children %}
-          {{ child.get_menu_title }}
+          <span>{{ child.get_menu_title }}</span>
           <i class="material-icons right">arrow_drop_down</i>
         {% else %}
-          {{ child.get_menu_title }}
+          <span>{{ child.get_menu_title }}</span>
         {% endif %}
       </div>
     </a>
@@ -32,7 +36,7 @@
                   <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>
                 {% endif %}
 
-                {{ child.get_menu_title }}
+                <span>{{ child.get_menu_title }}</span>
               </a>
             </li>
           {% endif %}

--- a/service_info/templates/cms/includes/sub_menu.html
+++ b/service_info/templates/cms/includes/sub_menu.html
@@ -8,7 +8,7 @@
         </a>
       </div>
     {% endif %}
-    <a class="collapsible-header waves-effect {% if child.ancestor %}active{% endif %}">
+    <a class="collapsible-header waves-effect {% if child.ancestor %}active{% endif %} {% if child.iconnameextension.icon_name %}has_icon{% endif %}">
       <div class="collapsible-header-wrap">
         {% if child.iconnameextension.icon_name %}
           <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>
@@ -30,7 +30,7 @@
               {% show_menu from_level to_level extra_inactive extra_active "cms/includes/sub_menu.html" "" "" child %}
             </li>
           {% else %}
-            <li class="no-padding {% if child.selected %}page-active{% endif %}">
+            <li class="no-padding {% if child.selected %}page-active{% endif %}  {% if child.iconnameextension.icon_name %}has_icon{% endif %}">
               <a href="{{ child.get_absolute_url }}" class="waves-effect">
                 {% if child.iconnameextension.icon_name %}
                   <i class="material-icons left">{{ child.iconnameextension.icon_name }}</i>


### PR DESCRIPTION
This fixes a couple of menu bugs:

* Somehow the JS that handled the submenu-staying-open feature in the old way of doing things got reintroduced. This snips it back out.
* Icons are added to submenu items. This calls for changes to the way item layout happens (because suddenly there's not just two DOM elements to handle). It also calls for some small ad-hoc style nudges to make the icons look right (somehow a left-aligned icon doesn't *look* like it lines up right with the text on other items, so you have to nudge it past the left edge a little).