### PR TITLE
Removing "row" class from wide pages

### DIFF
--- a/service_info/templates/cms/content-types/wide-page.html
+++ b/service_info/templates/cms/content-types/wide-page.html
@@ -4,7 +4,7 @@
 {% block main-class %}wide{% endblock main-class %}
 
 {% block wrap-content %}
-  <section class="row main-content">
+  <section class="main-content">
     {% block content %}
       {% placeholder "content" %}
     {% endblock content %}


### PR DESCRIPTION
For some reason—I don't really remember why—the "wide" template had the `row` class on its main content section. This was causing layout anomalies for no obvious reason.