### PR TITLE
Fixing image widths on blog detail pages

### DIFF
--- a/service_info/static/less/aldryn/aldryn-newsblog/article-detail.less
+++ b/service_info/static/less/aldryn/aldryn-newsblog/article-detail.less
@@ -3,7 +3,7 @@
 }
 
 .aldryn-newsblog-detail {
-  img {
+  .featured-image {
     width: 100%;
   }
 

--- a/service_info/templates/aldryn_newsblog/includes/article.html
+++ b/service_info/templates/aldryn_newsblog/includes/article.html
@@ -4,7 +4,7 @@
 <article class="aldryn-newsblog-article{% if article.is_featured %} aldryn-newsblog-featured{% endif %}{% if not article.published %} unpublished{% endif %}{% if article.future %} future{% endif %}">
     {% block newsblog_visual %}
         {% if article.featured_image_id %}
-            <img src="{% thumbnail article.featured_image.image 800x450 crop subject_location=article.featured_image.subject_location %}" alt="{{ article.featured_image.alt }}" class="img-responsive">
+            <img src="{% thumbnail article.featured_image.image 800x450 crop subject_location=article.featured_image.subject_location %}" alt="{{ article.featured_image.alt }}" class="img-responsive featured-image">
         {% endif %}
     {% endblock newsblog_visual %}
 


### PR DESCRIPTION
All images on newsblog detail pages were set to 100% width. This was extremely inappropriate in the case of, for instance, the icon appearing next to filenames on file plugin objects.

This 100% width was originally intended for featured images. This change restricts the width rule to that specific case.