### PR TITLE
Improve ratings submission

### DIFF
--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -23,6 +23,9 @@ function getInternetExplorerVersion () {
 
 jQuery(function ($) {
 
+  var page_id = $('input[name="page_id"]').val();
+  var page_ratings = JSON.parse(localStorage.getItem('page_ratings') || '{}');
+
   /*
     Activate Materialize mobile menu.
   */
@@ -85,12 +88,38 @@ jQuery(function ($) {
   });
 
   /*
+    Check for existing rating value and set buttons
+    accordingly.
+  */
+
+  if (typeof page_ratings[page_id] !== 'undefined') {
+    $('input:radio[name="rating"]')
+      .filter('[value="' + page_ratings[page_id] + '"]')
+      .prop('checked', true)
+    ;
+  }
+
+  /*
     Set up captcha callback.
   */
   window.__submit_captcha__ = function () {
+    var $rating = $('#page-rating');
+
     setTimeout(function () {
       $('#captcha-modal').closeModal();
-      $('#page-rating').submit();
     }, 1500);
+
+    console.log($rating.serialize());
+
+    $.post($rating.attr('action'), $rating.serialize())
+     .fail(function () {
+       $('#rating-fail-modal').openModal();
+     })
+     .done(function () {
+       var value = $rating.find('input:radio[name="rating"]:checked').val();
+       page_ratings[page_id] = value;
+       localStorage.setItem('page_ratings', JSON.stringify(page_ratings));
+     })
+    ;
   }
 });

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -108,6 +108,16 @@
                 ></div>
               </div>
             </div>
+
+            <div class="modal" id="rating-fail-modal">
+              <div class="modal-content">
+                <h4>{% trans "Error submitting rating" %}</h4>
+                <p>{% blocktrans %}
+                  There was an error submitting your page rating.
+                  Please check your connection and try again.
+                {% endblocktrans %}</p>
+              </div>
+            </div>
           </form>
         </section>
       {% endif %}


### PR DESCRIPTION
(Branches off #161 for the sake of not having to redo the HTML afterwards.)

Improves page rating submission in two ways:

* localStorage is used to track the user's page ratings. The `page_ratings` value on localStorage contains a JSON blob that maps from page IDs to assigned ratings. `page_ratings`'s value is set whenever a rating is assigned. When the page is loaded, `page_ratings` is inspected to see if it has a value for that page; if so, the radio button on the page is pre-set to whatever it should be.
* The form's data is now submitted not by the default browser "submit" functionality but by an AJAX request.