### PR TITLE
Adding Disqus localization

### DIFF
--- a/service_info/templates/aldryn_disqus/disqus.html
+++ b/service_info/templates/aldryn_disqus/disqus.html
@@ -1,0 +1,22 @@
+{% load sekizai_tags %}
+
+<div id="disqus_thread"></div>
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>
+
+{% addtoblock "js" %}
+    <script type="text/javascript">
+        var disqus_shortname = '{{ DISQUS_SHORTNAME }}';
+        var disqus_identifier = '{{ instance.page.pk }}';
+        var disqus_title = '{{ instance.page.get_page_title|escapejs }}';
+        var disqus_config = function () {
+            this.language = '{{ request.LANGUAGE_CODE }}';
+        };
+
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = 'http{% if request.is_secure %}s{% endif %}://' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+{% endaddtoblock %}


### PR DESCRIPTION
As usual, customizing the Aldryn Disqus add-on requires copying over the template from the `aldryn-disqus` repo and modifying it.

The only modification here is that which is spelled out [here](https://help.disqus.com/customer/portal/articles/466249-multi-lingual-websites): adding a function value to the variable `disqus_config` to set the language on `this` (what does `this` refer to here? who can truly say?). This will grab the language code from the `request` and use it to set the language on the plugin.

I've tried this out with English, Arabic, and French pages. It seems to work. Perhaps it would work anyway, however. It'll be hard to tell until it's on prod, where the anomalous situation was first encountered. In the meantime, it doesn't work *less* well.