### PR TITLE
FAQ style improvements

### DIFF
--- a/service_info/static/less/aldryn/aldryn-faq/includes/question-list.less
+++ b/service_info/static/less/aldryn/aldryn-faq/includes/question-list.less
@@ -1,3 +1,5 @@
+@import "../../../includes/flex.less";
+
 .aldryn-faq-list {
   .collapsible-body {
     padding: 2rem;
@@ -15,5 +17,21 @@
       padding: 0;
       margin-top: 1em;
     }
+  }
+}
+
+.collapsible-header-wrap {
+  .flex-layout();
+  .flex-direction(row);
+  .flex-wrap(nowrap);
+  .align-items(center);
+
+  > i {
+    .flex(0, 0, auto);
+  }
+
+  > span {
+    padding: 1rem 0;
+    line-height: 1.5rem;
   }
 }

--- a/service_info/templates/aldryn_faq/includes/ungrouped_question_list.html
+++ b/service_info/templates/aldryn_faq/includes/ungrouped_question_list.html
@@ -6,8 +6,8 @@
     <li>
         <div class="collapsible-header{% if forloop.first %} active{% endif %}">
             <div class="collapsible-header-wrap">
-                {% render_model question "title" %}
                 <i class="material-icons">info_outline</i>
+                <span>{% render_model question "title" %}</span>
             </div>
         </div>
         {% if view.config.app_data.config.show_description %}


### PR DESCRIPTION
FAQ items do not currently look very good if their question is so long that it stretches across multiple lines. This changes their layout so that they look less broken.