### PR TITLE
Better menu item padding

### DIFF
--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -166,7 +166,7 @@
 
     &.no-padding {
       > a {
-        padding: 1rem 30px;
+        padding: 0.5rem 30px;
       }
     }
 
@@ -270,10 +270,10 @@
             width: 48px;
           }
         }
-        padding: 1rem 0 1rem 30px;
+        padding: 0.5rem 0 0.5rem 30px;
         &.has_icon {
           // icon looks better slightly displaced to the left
-          padding: 1rem 0 1rem 25px;
+          padding: 0.5rem 0 0.5rem 25px;
         }
         width: 100%;
         box-sizing: border-box;

--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -166,7 +166,7 @@
 
     &.no-padding {
       > a {
-        padding: 0 30px;
+        padding: 1rem 30px;
       }
     }
 
@@ -239,7 +239,7 @@
     a {
       min-height: @side-nav-height;
       height: auto;
-      line-height: 1;
+      line-height: 1.25;
       .flex-layout();
       .flex-direction(row);
       .align-items(center);
@@ -266,14 +266,14 @@
             .flex-layout();
             .align-items(center);
             .justify-content(flex-start);
-            height: 48px;
+            height: auto;
             width: 48px;
           }
         }
-        padding: 0 0 0 30px;
+        padding: 1rem 0 1rem 30px;
         &.has_icon {
           // icon looks better slightly displaced to the left
-          padding: 0 0 0 25px;
+          padding: 1rem 0 1rem 25px;
         }
         width: 100%;
         box-sizing: border-box;


### PR DESCRIPTION
Right now, menu items are padded not using actual padding but just the `line-height` attribute. This works well … until they're more than a line long. And unfortunately this is often the case. Then they begin to bump nastily against the edges of their boxes.

This sets them up to use real, actual padding.

To test this, either create a page with a ridiculously long name and see how it looks in the menu (it should look like its menu item is very tall but nicely padded on the top and bottom) or otherwise manipulate the text content of an element in the dev tools to be unusually long.