### PR TITLE
Adding fullcalendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ service_info/static/css/site-ltr.css
 service_info/static/css/site-rtl.css
 service_info/static/css/site-mini-rtl.css
 service_info/static/css/materialize*
+service_info/static/css/fullcalendar*
 node_modules
 bundle_min.js
 feedback-help.hbs

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "backbone": "=1.2.0",
     "browserify": "^8.0.2",
     "es6-promise": "^2.0.1",
+    "fullcalendar": "^2.6.0",
     "handlebars": "^2.0.0",
     "hbsfy": "^2.2.1",
     "i18next-client": ">=1.7.7 <1.8.0",

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -165,6 +165,7 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
     os.path.join(PROJECT_ROOT, 'frontend'),
     os.path.join(PROJECT_ROOT, 'node_modules', 'materialize-css'),
+    os.path.join(PROJECT_ROOT, 'node_modules'),
 )
 
 LOCALE_PATHS = (

--- a/service_info/static/js/src/index.js
+++ b/service_info/static/js/src/index.js
@@ -85,6 +85,23 @@ jQuery(function ($) {
   });
 
   /*
+    Initialize calendar.
+  */
+  (function () {
+    var $calendar = $('.fullcalendar');
+    var key = $calendar.data('api-key');
+    var id = $calendar.data('calendar-id');
+    if (key && id) {
+      $calendar.fullCalendar({
+        googleCalendarApiKey: key
+        , events: {
+          googleCalendarId: id
+        }
+      });
+    }
+  })();
+
+  /*
     Set up captcha callback.
   */
   window.__submit_captcha__ = function () {

--- a/service_info/static/less/base-mini/base.less
+++ b/service_info/static/less/base-mini/base.less
@@ -68,3 +68,7 @@ header, #nav, footer, main, #language-picker {
     box-sizing: border-box;
   }
 }
+
+button:focus {
+  background-color: white;
+}

--- a/service_info/static/less/base-mini/components/calendar.less
+++ b/service_info/static/less/base-mini/components/calendar.less
@@ -1,0 +1,16 @@
+.fc {
+  .fc-icon {
+    color: black;
+  }
+
+  button.fc-button {
+    background: white !important;
+    background-image: none !important;
+  }
+
+  &.fc-unthemed .fc-today {
+    background: white;
+    color: black;
+    border-color: black;
+  }
+}

--- a/service_info/static/less/base-mini/components/index.less
+++ b/service_info/static/less/base-mini/components/index.less
@@ -9,3 +9,4 @@
 @import "blog-list.less";
 @import "ratings.less";
 @import "forms.less";
+@import "calendar.less";

--- a/service_info/templates/cms/base-mini.html
+++ b/service_info/templates/cms/base-mini.html
@@ -12,6 +12,7 @@
     {% else %}
       <link href="{% static 'css/materialize.min.css' %}" rel="stylesheet">
     {% endif %}
+    <link href="{% static 'css/fullcalendar.min.css' %}" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     {% if request.LANGUAGE_CODE == 'ar' %}
@@ -139,6 +140,11 @@
 
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.3/js/materialize.min.js"></script>
+    <script src="{% static 'moment/min/moment.min.js' %}"></script>
+    <script src="{% static 'fullcalendar/dist/fullcalendar.min.js' %}"></script>
+    {% with 'fullcalendar/dist/lang/'|add:request.LANGUAGE_CODE|add:'.js' as calendar_lg %}
+      <script src="{% static calendar_lg %}"></script>
+    {% endwith %}
     <script src="{% static 'js/dist/bundle.js' %}"></script>
     <script src="https://www.google.com/recaptcha/api.js?hl={{ request.LANGUAGE_CODE }}" async defer></script>
     {% render_block "js" %}

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -12,6 +12,7 @@
     {% else %}
       <link href="{% static 'css/materialize.min.css' %}" rel="stylesheet">
     {% endif %}
+    <link href="{% static 'css/fullcalendar.min.css' %}" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     {% if request.LANGUAGE_CODE == 'ar' %}
@@ -174,6 +175,13 @@
 
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.3/js/materialize.min.js"></script>
+    <script src="{% static 'moment/min/moment.min.js' %}"></script>
+    <script src="{% static 'fullcalendar/dist/fullcalendar.min.js' %}"></script>
+    {% if request.LANGUAGE_CODE != 'en' %}
+      {% with 'fullcalendar/dist/lang/'|add:request.LANGUAGE_CODE|add:'.js' as calendar_lg %}
+        <script src="{% static calendar_lg %}"></script>
+      {% endwith %}
+    {% endif %}
     <script src="{% static 'js/dist/bundle.js' %}"></script>
     <script src="https://www.google.com/recaptcha/api.js?hl={{ request.LANGUAGE_CODE }}" async defer></script>
     {% render_block "js" %}


### PR DESCRIPTION
Google's own iframe-based calendar embedding is unsatisfactory and non-responsive. It's better to use a third-party plugin that consumes the Google calendar API. That is what this branch adds.

The preliminary steps for testing out this addition are outlined in the [fullcalendar Google Calendar instructions page](http://fullcalendar.io/docs/google_calendar/). The steps can be summarized as follows:

1. Create a Google Calendar API Key.
2. Create a Google calendar and make it public.
3. Obtain the ID for the calendar.

The next step is specific to the implementation here. What you must do is add a snippet of HTML like the following to a text plugin (or any other plugin allowing raw HTML editing):

    <div class="fullcalendar" data-api-key="<your API key>" data-calendar-id="<your calendar ID>"></div>

This element, once added and saved, will *no longer be visible* in the text plugin's HTML source in future edits. To change or remove it, the entire text plugin must be removed.

Once the element has been added to the source, the page can be refreshed, and the JavaScript that initializes the calendar will find the element, pull out the necessary data from its `data-` attributes, and initialize the calendar. Any number of calendars can be set up this way; they all just have to have the `fullcalendar` class and the relevant data.

The calendar widget is set up to be sensitive to the page's language. The `request.LANGUAGE_CODE` value is used to pick out a separate localization JS file. No special RTL transform of the CSS is necessary; fullcalendar's style sheet is apparently smart enough to handle that on its own.