### PR TITLE
SC-151 - Switch to Caktus fork of aldryn-common for pagination fix

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,8 @@ aldryn-faq==1.0.11
       URLObject==2.4.0
     django-standard-form==1.1.1
       # django-classy-tags
-    aldryn-common==1.0.0
+    # Has Py3K issue with pagination: aldryn-common==1.0.0
+    git+git://github.com/caktus/aldryn-common.git@d8287f8863744f3279fc89e55405f13c59ad20dc#egg=aldryn-common
       # aldry-boilerplates
       # django-sortedm2m
   aldryn-translation-tools==0.2.1


### PR DESCRIPTION
This fix for Py3K is required when "lots of" search hits are found:

https://github.com/aldryn/aldryn-common/pull/15