### PR TITLE
Style fixes for menu item alignment

### DIFF
--- a/service_info/static/less/base/header/nav.less
+++ b/service_info/static/less/base/header/nav.less
@@ -262,7 +262,7 @@
           }
 
           i {
-            .flex(0, 0, 36px);
+            .flex(0, 0, 40px);
             .flex-layout();
             .align-items(center);
             .justify-content(flex-start);
@@ -273,7 +273,7 @@
         padding: 0.5rem 0 0.5rem 30px;
         &.has_icon {
           // icon looks better slightly displaced to the left
-          padding: 0.5rem 0 0.5rem 25px;
+          padding: 0.5rem 0 0.5rem 30px;
         }
         width: 100%;
         box-sizing: border-box;
@@ -334,7 +334,7 @@
 
     > ul > li.has_icon > a {
       // visual adjustment for icons on non-parent child list item
-      padding: 0 30px 0 25px;
+      padding: 0 30px 0 30px;
     }
   }
 }


### PR DESCRIPTION
As revealed by staging and prod, the alignment of elements within menu items that are parents and have icons was bad. This corrects that.