### PR TITLE
Correcting fullcalendar static files path

### DIFF
--- a/service_info/templates/cms/base-mini.html
+++ b/service_info/templates/cms/base-mini.html
@@ -20,7 +20,7 @@
     {% else %}
       <link href="{% static 'css/materialize.min.css' %}" rel="stylesheet">
     {% endif %}
-    <link href="{% static 'css/fullcalendar.min.css' %}" rel="stylesheet">
+    <link href="{% static 'fullcalendar/dist/fullcalendar.min.css' %}" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <link rel="shortcut icon" href="{% static 'images/sm-favicon.png' %}">

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -20,7 +20,7 @@
     {% else %}
       <link href="{% static 'css/materialize.min.css' %}" rel="stylesheet">
     {% endif %}
-    <link href="{% static 'css/fullcalendar.min.css' %}" rel="stylesheet">
+    <link href="{% static 'fullcalendar/dist/fullcalendar.min.css' %}" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <link rel="shortcut icon" href="{% static 'images/sm-favicon.png' %}">


### PR DESCRIPTION
I was originally going to add a build process step for fullcalendar to handle RTL conversion. This turned out to be unnecessary. But I forgot to change the stylesheet link after this realization, leaving a reference to an untracked file.