### PR TITLE
Adding .h-scroll class styles

### DIFF
--- a/service_info/static/less/base-mini/base.less
+++ b/service_info/static/less/base-mini/base.less
@@ -72,3 +72,8 @@ header, #nav, footer, main, #language-picker {
 button:focus {
   background-color: white;
 }
+
+.h-scroll {
+  width: 100%;
+  overflow-x: scroll;
+}

--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -76,3 +76,8 @@ table {
   margin: 0 auto;
   max-width: 820px;
 }
+
+.h-scroll {
+  width: 100%;
+  overflow-x: scroll;
+}


### PR DESCRIPTION
For many elements, it's useful to be able to scroll past the horizontal extent of the viewable area. Tables are a good example.

Unfortunately, the easiest way to accomplish this is to ask the content creator to wrap these elements in a `<div class="h-scroll">` element, whose styles are set up in this patch.

To test this, I suggest copying [this gigantic table](https://serviceinfo.rescue.org/en/find-information/legal-information/lost-documents/), wrapping it in an `.h-scroll` element, and verifying that you can scroll horizontally within the table on small screens.