### PR TITLE
Adds Moment to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "browserify": "^8.0.2",
     "es6-promise": "^2.0.1",
     "fullcalendar": "^2.6.0",
+    "moment": ">=2.5.0",
     "handlebars": "^2.0.0",
     "hbsfy": "^2.2.1",
     "i18next-client": ">=1.7.7 <1.8.0",


### PR DESCRIPTION
This should ensure that Moment is installed in the top-level node_modules directory even in old versions of npm, which should make it reliably available within templates.