### PR TITLE
Adding legacy deps to Gulp build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ frontend/config.json
 frontend/styles/site.css
 frontend/styles/site-ltr.css
 frontend/styles/site-rtl.css
+service_info/static/lib/
 service_info/static/js/dist/
 service_info/static/css/site.css
 service_info/static/css/site-mini.css

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -109,7 +109,26 @@ gulp.task('compile_less_cms_materialize', function () {
     .pipe(rename({ suffix: '-rtl' }))
     .pipe(gulp.dest('service_info/static/css'))
   ;
-})
+});
+
+gulp.task('copy_legacy_dependencies', function () {
+  var legacy_dirs = [
+    /*
+      Pairs specifying dependencies to copy:
+        1. path (relative to project root) of dependencies to use as src
+        2. path (relative to service_info/static/lib/) to use as dest
+    */
+    ['node_modules/fullcalendar/**/*', 'fullcalendar']
+    , ['node_modules/fullcalendar/node_modules/moment/**/*', 'moment']
+  ];
+
+  legacy_dirs.forEach(function (src_dest) {
+    gulp.src(src_dest[0])
+      .pipe(gulp.dest('service_info/static/lib/' + src_dest[1]))
+    ;
+
+  });
+});
 
 gulp.task('compile_less', [
   options.app ? 'compile_less_app' : 'noop'
@@ -223,7 +242,7 @@ gulp.task('closure', [
   , options.cms ? 'closure_cms' : 'noop'
 ], function() {});
 
-gulp.task('build', ['closure', 'compile_less', 'injectEnvConfig'], function(){});
+gulp.task('build', ['closure', 'compile_less', 'injectEnvConfig', 'copy_legacy_dependencies'], function(){});
 
 // Notifies livereload of changes detected
 // by `gulp.watch()`

--- a/service_info/templates/cms/base-mini.html
+++ b/service_info/templates/cms/base-mini.html
@@ -150,11 +150,13 @@
 
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.3/js/materialize.min.js"></script>
-    <script src="{% static 'moment/min/moment.min.js' %}"></script>
-    <script src="{% static 'fullcalendar/dist/fullcalendar.min.js' %}"></script>
-    {% with 'fullcalendar/dist/lang/'|add:request.LANGUAGE_CODE|add:'.js' as calendar_lg %}
-      <script src="{% static calendar_lg %}"></script>
-    {% endwith %}
+    <script src="{% static 'lib/moment/min/moment.min.js' %}"></script>
+    <script src="{% static 'lib/fullcalendar/dist/fullcalendar.min.js' %}"></script>
+    {% if request.LANGUAGE_CODE != 'en' %}
+      {% with 'lib/fullcalendar/dist/lang/'|add:request.LANGUAGE_CODE|add:'.js' as calendar_lg %}
+        <script src="{% static calendar_lg %}"></script>
+      {% endwith %}
+    {% endif %}
     <script src="{% static 'js/dist/bundle.js' %}"></script>
     <script src="https://www.google.com/recaptcha/api.js?hl={{ request.LANGUAGE_CODE }}" async defer></script>
     {% render_block "js" %}

--- a/service_info/templates/cms/base.html
+++ b/service_info/templates/cms/base.html
@@ -203,10 +203,10 @@
 
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.3/js/materialize.min.js"></script>
-    <script src="{% static 'moment/min/moment.min.js' %}"></script>
-    <script src="{% static 'fullcalendar/dist/fullcalendar.min.js' %}"></script>
+    <script src="{% static 'lib/moment/min/moment.min.js' %}"></script>
+    <script src="{% static 'lib/fullcalendar/dist/fullcalendar.min.js' %}"></script>
     {% if request.LANGUAGE_CODE != 'en' %}
-      {% with 'fullcalendar/dist/lang/'|add:request.LANGUAGE_CODE|add:'.js' as calendar_lg %}
+      {% with 'lib/fullcalendar/dist/lang/'|add:request.LANGUAGE_CODE|add:'.js' as calendar_lg %}
         <script src="{% static calendar_lg %}"></script>
       {% endwith %}
     {% endif %}


### PR DESCRIPTION
In order to ensure that misplaced dependencies cause a fail at build time rather than runtime, it's a good idea to get the build process to copy those dependencies into some directory we control.

This way, if there's a problem with Node versioning that causes dependencies to end up somewhere unexpected, we'll know early on instead of waiting to see 404s.

In this case, the `fullcalendar` and `moment` dependencies are included in the gulpfile.

The `.gitignore` is amended to ignore the `service_info/static/lib` build target.