### PR TITLE
Mobile menu style fix

### DIFF
--- a/service_info/static/less/base/header/mobile-nav.less
+++ b/service_info/static/less/base/header/mobile-nav.less
@@ -32,4 +32,23 @@
       height: 100%;
     }
   }
+
+  .collapsible-header {
+    // padding: 0 0 0 30px;
+  }
+
+  i {
+    height: 32px;
+    line-height: 32px;
+  }
+
+  ul {
+    .overlay {
+      a {
+        &:hover {
+          background-color: transparent;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Making the desktop menu look inadvertently broke the mobile menu. This fixes the height of items and the hover behavior of the overlays.