### PR TITLE
Switch from Caktus fork of aldryn-common to new 1.0.1 release

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,8 +63,7 @@ aldryn-faq==1.0.11
       URLObject==2.4.0
     django-standard-form==1.1.1
       # django-classy-tags
-    # Has Py3K issue with pagination: aldryn-common==1.0.0
-    git+git://github.com/caktus/aldryn-common.git@d8287f8863744f3279fc89e55405f13c59ad20dc#egg=aldryn-common
+    aldryn-common==1.0.1
       # aldry-boilerplates
       # django-sortedm2m
   aldryn-translation-tools==0.2.1


### PR DESCRIPTION
This is the fix we were maintaining in our fork:

https://github.com/aldryn/aldryn-common/pull/15

An easy way to reproduce the problem was to search for a common term like "health" in the backend's full text search (using prod db).