### PR TITLE
Small front-end bugfixes

### DIFF
--- a/service_info/static/less/base-mini/base.less
+++ b/service_info/static/less/base-mini/base.less
@@ -77,3 +77,7 @@ button:focus {
   width: 100%;
   overflow-x: scroll;
 }
+
+.clearfix {
+  overflow: hidden;
+}

--- a/service_info/static/less/base/base.less
+++ b/service_info/static/less/base/base.less
@@ -81,3 +81,7 @@ table {
   width: 100%;
   overflow-x: scroll;
 }
+
+.clearfix {
+  overflow: hidden;
+}

--- a/service_info/templates/cms/content-types/two-column.html
+++ b/service_info/templates/cms/content-types/two-column.html
@@ -7,10 +7,16 @@
     <section class="row main-content">
         <div class="col s12 m9 main-column {% block main-column-class %}{% endblock main-column-class %}">
             {% block content %}
+                <section>
+                    {% placeholder "content" %}
+                </section>
             {% endblock content %}
         </div>
         <div class="col s12 m3 secondary-column {% block secondary-column-class %}{% endblock secondary-column-class %}">
             {% block sidebar-content %}
+                <section>
+                    {% placeholder "sidebar_content" %}
+                </section>
             {% endblock sidebar-content %}
         </div>
     </section>


### PR DESCRIPTION
Fixing a couple of issues encountered while preparing presentation:

* `two-column.html` has no placeholders! This adds them. (Evidently nobody was using this template.)
* The `.clearfix` class doesn't actually work on Chrome. (Example of this behavior: create a multi-column layout plugin on a page and fill in its columns. Then create another plugin after it. Because the multi-column layout's clearfix is not succeeding in giving the box any dimensions, your other plugin will be pushed off to the right of the multicolumn plugin.) This adds an `overflow: hidden` rule that makes it do so.