### PR TITLE
SC-119 change site association of CMS pages

### DIFF
--- a/service_info_cms/management/commands/change_cms_site.py
+++ b/service_info_cms/management/commands/change_cms_site.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     args = '< --from original_site_domain --to new_site_domain | --list >'
 
     option_list = BaseCommand.option_list + (
-        make_option('--from', default=None,
+        make_option('--from', default=None, dest='orig',
                     help='Domain of original site'),
         make_option('--to', default=None,
                     help='Domain of new site'),
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                 self.stdout.write('  {0}\n'.format(site))
             return
 
-        from_site_domain = options['from']
+        from_site_domain = options['orig']
         to_site_domain = options['to']
 
         if not from_site_domain or not to_site_domain:

--- a/service_info_cms/management/commands/change_cms_site.py
+++ b/service_info_cms/management/commands/change_cms_site.py
@@ -1,0 +1,55 @@
+from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.sites.models import Site
+
+from service_info_cms.utils import change_cms_site
+
+
+class Command(BaseCommand):
+    """ Similar: cms/management/commands/subcommands/copy_site.py """
+
+    help = 'Move the CMS pages from one site to another'
+    args = '< --from original_site_domain --to new_site_domain | --list >'
+
+    option_list = BaseCommand.option_list + (
+        make_option('--from', default=None,
+                    help='Domain of original site'),
+        make_option('--to', default=None,
+                    help='Domain of new site'),
+        make_option('--list', default=None, action='store_true',
+                    help='List available sites')
+    )
+
+    def handle(self, *args, **options):
+        if options['list']:
+            self.stdout.write('Available sites:')
+            for site in Site.objects.all():
+                self.stdout.write('  {0}\n'.format(site))
+            return
+
+        from_site_domain = options['from']
+        to_site_domain = options['to']
+
+        if not from_site_domain or not to_site_domain:
+            raise CommandError('Use --list or specify both --from and --to arguments ')
+        if from_site_domain == to_site_domain:
+            raise CommandError('Original site and new site must be different')
+
+        to_site = self.get_site(to_site_domain)
+        from_site = self.get_site(from_site_domain)
+
+        total_pages_moved, total_placeholders_moved = change_cms_site(from_site, to_site)
+        self.stdout.write('Moved {0} pages from site {1} to site {2}.\n'.format(
+            total_pages_moved, from_site_domain, to_site_domain
+        ))
+        self.stdout.write('Moved {0} static placeholders from site {1} to site {2}.\n'.format(
+            total_placeholders_moved, from_site_domain, to_site_domain
+        ))
+
+    @staticmethod
+    def get_site(domain):
+        try:
+            return Site.objects.get(domain=domain)
+        except Site.DoesNotExist:
+            raise CommandError('Unknown site: {0}'.format(domain))

--- a/service_info_cms/tests/test_change_site.py
+++ b/service_info_cms/tests/test_change_site.py
@@ -1,0 +1,69 @@
+import io
+
+from django.test import TestCase
+
+from cms.models import Page
+from django.contrib.sites.models import Site
+from django.core.management import call_command, CommandError
+
+from email_user.tests.factories import EmailUserFactory
+from service_info_cms import utils
+
+
+class BaseMovePagesTest(TestCase):
+
+    def setUp(self):
+        self.user = EmailUserFactory(is_superuser=True)
+        # Use the existing sites; their use of hard-coded pks breaks the ability to
+        # add arbitrary additional sites for this test.
+        self.orig_site_domain = 'serviceinfo.rescue.org'
+        self.new_site_domain = 'serviceinfo-staging.rescue.org'
+        self.orig_site = Site.objects.get(domain=self.orig_site_domain)
+        self.new_site = Site.objects.get(domain=self.new_site_domain)
+        utils.create_essential_pages(self.user, self.orig_site)
+
+    def pre_move(self):
+        starting_counts = {
+            'orig_pages': Page.objects.filter(site=self.orig_site).count(),
+            'new_pages': Page.objects.filter(site=self.new_site).count(),
+        }
+        self.assertEqual(0, starting_counts['new_pages'])
+        self.assertGreater(starting_counts['orig_pages'], 0)
+        return starting_counts
+
+    def post_move(self, starting_counts):
+        ending_counts = {
+            'orig_pages': Page.objects.filter(site=self.orig_site).count(),
+            'new_pages': Page.objects.filter(site=self.new_site).count(),
+        }
+        self.assertEqual(starting_counts['orig_pages'], ending_counts['new_pages'])
+        self.assertEqual(ending_counts['new_pages'], starting_counts['orig_pages'])
+
+
+class TestMovePagesFunction(BaseMovePagesTest):
+
+    def test_move_function(self):
+        starting_counts = self.pre_move()
+        utils.change_cms_site(self.orig_site, self.new_site)
+        self.post_move(starting_counts)
+
+
+class TestMovePagesCommand(BaseMovePagesTest):
+
+    def test_move_command(self):
+        starting_counts = self.pre_move()
+        hide_output = io.StringIO()
+        call_command('change_cms_site', orig=self.orig_site_domain, to=self.new_site_domain,
+                     stdout=hide_output)
+        self.post_move(starting_counts)
+
+
+class TestBadMovePagesCommands(BaseMovePagesTest):
+
+    def test_same_domains(self):
+        with self.assertRaises(CommandError):
+            call_command('change_cms_site', orig=self.orig_site_domain, to=self.orig_site_domain)
+
+    def test_only_one_domain(self):
+        with self.assertRaises(CommandError):
+            call_command('change_cms_site', orig=self.orig_site_domain)

--- a/service_info_cms/utils.py
+++ b/service_info_cms/utils.py
@@ -1,9 +1,10 @@
 from cms.api import create_page, create_title, publish_page
-from cms.models import Page
+from cms.models import Page, StaticPlaceholder
 from django.conf import settings
+from django.db import transaction
 
 
-def create_essential_pages(page_publisher):
+def create_essential_pages(page_publisher, site=None):
     languages = [entry[0] for entry in settings.LANGUAGES]
 
     if not Page.objects.count():
@@ -11,7 +12,8 @@ def create_essential_pages(page_publisher):
             title='Home',
             template='cms/content-types/homepage.html',
             language=languages[0],
-            published=True
+            published=True,
+            site=site
         )
         # Having the Home page in all languages is not essential.
 
@@ -22,9 +24,30 @@ def create_essential_pages(page_publisher):
             language=languages[0],
             apphook='AldrynSearchApphook',
             reverse_id='search-results',
-            published=True
+            published=True,
+            site=site
         )
         # The search results page must exist in all languages.
         for lang in languages[1:]:
             create_title(language=lang, title='Search', page=search_page)
             publish_page(page=search_page, user=page_publisher, language=lang)
+
+
+def change_cms_site(from_site, to_site):
+    pages = Page.objects.filter(site=from_site)
+    placeholders = StaticPlaceholder.objects.filter(site=from_site)
+
+    total_pages_moved = 0
+    total_placeholders_moved = 0
+
+    with transaction.atomic():
+        for page in pages:
+            page.site = to_site
+            page.save()
+            total_pages_moved += 1
+        for placeholder in placeholders:
+            placeholder.site = to_site
+            placeholder.save()
+            total_placeholders_moved += 1
+
+    return total_pages_moved, total_placeholders_moved


### PR DESCRIPTION
Changing the Site associated with CMS pages is part of using a prod db on staging or dev, or using a staging db on dev.  Eliminating the use of sites altogether was considered, but handing the non-CMS use of sites wasn't practical in the available time.

Essentially, after a db is copied (from production to dev, for example), in order to access the CMS pages this management command will be run to change Pages which did refer to the production site to instead refer to the dev site.  (StaticPlaceholder site associations are also changed, though the ones in current use apply to all sites and don't have a real association, and are thus ignored by the command.)