### PR TITLE
Install/enable DjangoCMS Snippets plug-in

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -120,4 +120,5 @@ aldryn-forms==2.0.4
   # django-filer
   django-sizefield==0.9
   # aldryn-boilerplates
+djangocms-snippet==1.8.2
 elasticsearch==2.1.0

--- a/service_info/settings/base.py
+++ b/service_info/settings/base.py
@@ -301,6 +301,7 @@ INSTALLED_APPS = (
     'aldryn_forms.contrib.email_notifications',
     'captcha',
     'emailit',
+    'djangocms_snippet',
     # End Django CMS
     # Load after easy_thumbnails so that its thumbnail template tag (unused
     # in this project) is hidden.

--- a/service_info/tests/test_missing_migrations.py
+++ b/service_info/tests/test_missing_migrations.py
@@ -36,11 +36,14 @@ from django.core import management
 #     - Alter field form_template on formplugin
 #     - Alter field redirect_type on formplugin
 #     - Alter field language on formsubmission
-#
+# Migrations for 'djangocms_snippet':
+#   0006_auto_20160823_0131.py:
+#     - Alter field slug on snippet#
 # $ python manage.py sqlmigrate aldryn_faq 0011
 # $ python manage.py sqlmigrate email_notifications 0002
 # $ python manage.py sqlmigrate aldryn_newsblog 0009
 # $ python manage.py sqlmigrate aldryn_forms 0005
+# $ python manage.py sqlmigrate djangocms_snippet 0006
 # $
 #
 # If this is a third-party package and the "missing" migration doesn't affect
@@ -88,6 +91,16 @@ EXPECTED_CHANGES = {
         #     preserve_default=True,
         # ),
         '- Alter field template_prefix on newsblogconfig',
+    ],
+    'djangocms_snippet': [
+        # This is Py3K-izing default=b''
+        # migrations.AlterField(
+        #     model_name='snippet',
+        #     name='slug',
+        #     field=models.SlugField(max_length=75, default='', verbose_name='slug', unique=True),
+        #     preserve_default=True,
+        # ),
+        '- Alter field slug on snippet',
     ],
     'email_notifications': [  # part of aldryn_forms package
         # Changing choices= because the project version has b'default' instead of 'default'


### PR DESCRIPTION
For a how-to guide, refer to https://docs.google.com/document/d/18xiz0c2VSsT15zke4WmtQL1eeqg87rB4cJiIBih_0e0/edit#

Search is not enabled (i.e., DJANGOCMS_SNIPPET_SEARCH isn't set)
* not requested by the client
* unclear how to make it work, as naive attempt was unsuccessful